### PR TITLE
Here's a summary of the recent changes I've made:

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -31,8 +31,7 @@ func main() {
 	// If NewLogger was to return an instance and we set it globally, that would happen here.
 	// For now, we can assume the logger.Info, logger.Error, etc. will work.
 	// If we need to set log level based on config:
-	// logger.SetLevel(cfg.LogLevel) // This function would need to be added to logger pkg
-	_ = logger.NewLogger(cfg.LogLevel) // This initializes the global logger in our current setup
+	logger.SetGlobalLogLevel(cfg.LogLevel) // Use the new function to set the global logger's level
 
 	logger.Info("OBI Scalping Bot starting...")
 	logger.Infof("Loaded configuration from: %s", *configPath)


### PR DESCRIPTION
- I've fixed an initialization cycle between the global `std` logger and the `NewLogger` function in `pkg/logger/logger.go`.
- The global `std` logger is now initialized directly with default settings.
- `NewLogger` now only returns a new logger instance without modifying any global state.
- I've added a `SetGlobalLogLevel` function to `pkg/logger` to allow you to configure the global logger's level based on your application settings.
- I've updated `cmd/bot/main.go` to use `SetGlobalLogLevel` for initializing the logger according to the loaded configuration.