### PR TITLE
feat: Implement L2 order book processing and OBI calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/your-org/obi-scalp-bot
 go 1.24.3
 
 require (
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/exchange/coincheck/types.go
+++ b/internal/exchange/coincheck/types.go
@@ -1,4 +1,80 @@
 // Package coincheck handles interactions with the Coincheck exchange.
 package coincheck
 
-// TODO: Define types for Coincheck API responses and WebSocket messages
+import "strconv"
+
+// BookLevel represents a single price level in the order book.
+// Rate and Amount are strings as received from the WebSocket API.
+type BookLevel struct {
+	Rate   string
+	Amount string
+}
+
+// RateFloat64 converts the Rate string to float64.
+func (bl *BookLevel) RateFloat64() (float64, error) {
+	return strconv.ParseFloat(bl.Rate, 64)
+}
+
+// AmountFloat64 converts the Amount string to float64.
+func (bl *BookLevel) AmountFloat64() (float64, error) {
+	return strconv.ParseFloat(bl.Amount, 64)
+}
+
+// OrderBookData contains the bids and asks arrays.
+type OrderBookData struct {
+	Bids          [][]string `json:"bids"`
+	Asks          [][]string `json:"asks"`
+	LastUpdateAt string     `json:"last_update_at"`
+}
+
+// OrderBookUpdate represents an update to the order book received via WebSocket.
+// The first element is the pair (e.g., "btc_jpy").
+// The second element is an object containing bids, asks, and last_update_at.
+// We define it this way to make JSON unmarshaling easier.
+type OrderBookUpdate []interface{}
+
+// Pair returns the trading pair string.
+func (obu OrderBookUpdate) Pair() string {
+	if len(obu) > 0 {
+		if pair, ok := obu[0].(string); ok {
+			return pair
+		}
+	}
+	return ""
+}
+
+// Data returns the order book data.
+func (obu OrderBookUpdate) Data() (OrderBookData, bool) {
+	if len(obu) > 1 {
+		if dataMap, ok := obu[1].(map[string]interface{}); ok {
+			var data OrderBookData
+			if bids, ok := dataMap["bids"].([]interface{}); ok {
+				for _, b := range bids {
+					if bidSlice, ok := b.([]interface{}); ok && len(bidSlice) == 2 {
+						rate, rateOk := bidSlice[0].(string)
+						amount, amountOk := bidSlice[1].(string)
+						if rateOk && amountOk {
+							data.Bids = append(data.Bids, []string{rate, amount})
+						}
+					}
+				}
+			}
+			if asks, ok := dataMap["asks"].([]interface{}); ok {
+				for _, a := range asks {
+					if askSlice, ok := a.([]interface{}); ok && len(askSlice) == 2 {
+						rate, rateOk := askSlice[0].(string)
+						amount, amountOk := askSlice[1].(string)
+						if rateOk && amountOk {
+							data.Asks = append(data.Asks, []string{rate, amount})
+						}
+					}
+				}
+			}
+			if lastUpdateAt, ok := dataMap["last_update_at"].(string); ok {
+				data.LastUpdateAt = lastUpdateAt
+			}
+			return data, true
+		}
+	}
+	return OrderBookData{}, false
+}

--- a/pkg/obi/obi.go
+++ b/pkg/obi/obi.go
@@ -1,0 +1,152 @@
+// Package obi provides types and functions for calculating Order Book Imbalance (OBI).
+package obi
+
+import (
+	"container/heap"
+	"strconv"
+	"time"
+
+	"github.com/your-org/obi-scalp-bot/internal/exchange/coincheck"
+)
+
+// OBIResult holds the calculated OBI values for different levels and the timestamp.
+type OBIResult struct {
+	OBI8      float64   // Order Book Imbalance for top 8 levels
+	OBI16     float64   // Order Book Imbalance for top 16 levels
+	Timestamp time.Time // Timestamp of the OBI calculation (derived from last_update_at or current time)
+}
+
+// PriceLevel represents a price level with rate and amount.
+// Used for heap implementation.
+type PriceLevel struct {
+	Rate   float64
+	Amount float64
+	IsBid  bool // true for bids (higher rate is better), false for asks (lower rate is better)
+}
+
+// PriceLevelHeap implements heap.Interface for a list of PriceLevel.
+// For bids, it's a max-heap based on rate.
+// For asks, it's a min-heap based on rate.
+type PriceLevelHeap []*PriceLevel
+
+func (h PriceLevelHeap) Len() int { return len(h) }
+func (h PriceLevelHeap) Less(i, j int) bool {
+	// For bids (max-heap): higher rate is "less" (comes earlier)
+	// For asks (min-heap): lower rate is "less" (comes earlier)
+	if h[i].IsBid {
+		return h[i].Rate > h[j].Rate // Max-heap for bids
+	}
+	return h[i].Rate < h[j].Rate // Min-heap for asks
+}
+func (h PriceLevelHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+// Push and Pop use pointer receivers because they modify the slice's length,
+// not just its contents.
+func (h *PriceLevelHeap) Push(x interface{}) {
+	*h = append(*h, x.(*PriceLevel))
+}
+
+func (h *PriceLevelHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// CalculateOBI calculates the Order Book Imbalance for the given levels.
+// It takes an OrderBookUpdate (which is []interface{} from Coincheck) and the number of levels for OBI calculation.
+func CalculateOBI(orderBookUpdate coincheck.OrderBookUpdate, levels ...int) (OBIResult, error) {
+	result := OBIResult{}
+	data, ok := orderBookUpdate.Data()
+	if !ok {
+		// If data extraction fails, return an empty result or an error
+		// For now, let's return an empty result and rely on Timestamp being zero.
+		// Consider returning an error if this case needs specific handling.
+		return result, nil // Or an error indicating invalid data format
+	}
+
+	if data.LastUpdateAt != "" {
+		ts, err := strconv.ParseInt(data.LastUpdateAt, 10, 64)
+		if err == nil {
+			result.Timestamp = time.Unix(ts, 0)
+		} else {
+			result.Timestamp = time.Now().UTC() // Fallback if parsing fails
+		}
+	} else {
+		result.Timestamp = time.Now().UTC() // Fallback if LastUpdateAt is empty
+	}
+
+	bidHeap := &PriceLevelHeap{}
+	askHeap := &PriceLevelHeap{}
+	heap.Init(bidHeap)
+	heap.Init(askHeap)
+
+	for _, b := range data.Bids {
+		rate, errRate := strconv.ParseFloat(b[0], 64)
+		amount, errAmount := strconv.ParseFloat(b[1], 64)
+		if errRate == nil && errAmount == nil && amount > 0 { // Ensure amount is positive
+			heap.Push(bidHeap, &PriceLevel{Rate: rate, Amount: amount, IsBid: true})
+		}
+	}
+
+	for _, a := range data.Asks {
+		rate, errRate := strconv.ParseFloat(a[0], 64)
+		amount, errAmount := strconv.ParseFloat(a[1], 64)
+		if errRate == nil && errAmount == nil && amount > 0 { // Ensure amount is positive
+			heap.Push(askHeap, &PriceLevel{Rate: rate, Amount: amount, IsBid: false})
+		}
+	}
+
+	maxLevel := 0
+	for _, l := range levels {
+		if l > maxLevel {
+			maxLevel = l
+		}
+	}
+
+	sumBids := make(map[int]float64)
+	sumAsks := make(map[int]float64)
+
+	currentBidsTotal := 0.0
+	for i := 0; i < maxLevel && bidHeap.Len() > 0; i++ {
+		level := heap.Pop(bidHeap).(*PriceLevel)
+		currentBidsTotal += level.Amount
+		for _, l := range levels {
+			if i < l {
+				sumBids[l] += level.Amount
+			}
+		}
+	}
+
+	currentAsksTotal := 0.0
+	for i := 0; i < maxLevel && askHeap.Len() > 0; i++ {
+		level := heap.Pop(askHeap).(*PriceLevel)
+		currentAsksTotal += level.Amount
+		for _, l := range levels {
+			if i < l {
+				sumAsks[l] += level.Amount
+			}
+		}
+	}
+
+	for _, l := range levels {
+		totalBids := sumBids[l]
+		totalAsks := sumAsks[l]
+		var obiValue float64
+		if totalBids+totalAsks > 0 { // Avoid division by zero
+			obiValue = (totalBids - totalAsks) / (totalBids + totalAsks)
+		} else {
+			obiValue = 0 // Or NaN, depending on desired behavior for empty/zero books
+		}
+
+		if l == 8 {
+			result.OBI8 = obiValue
+		} else if l == 16 {
+			result.OBI16 = obiValue
+		}
+		// Add more cases if other levels are needed
+	}
+
+	return result, nil
+}

--- a/pkg/obi/obi_test.go
+++ b/pkg/obi/obi_test.go
@@ -1,0 +1,222 @@
+// Package obi_test contains tests for the OBI calculation logic.
+package obi_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/your-org/obi-scalp-bot/internal/exchange/coincheck"
+	"github.com/your-org/obi-scalp-bot/pkg/obi"
+)
+
+func TestCalculateOBI(t *testing.T) {
+	// Helper to create OrderBookUpdate for tests
+	newOrderBookUpdate := func(bids, asks [][]string, lastUpdateAt string) coincheck.OrderBookUpdate {
+		data := map[string]interface{}{
+			"bids":           make([]interface{}, len(bids)),
+			"asks":           make([]interface{}, len(asks)),
+			"last_update_at": lastUpdateAt,
+		}
+		for i, bid := range bids {
+			data["bids"].([]interface{})[i] = []interface{}{bid[0], bid[1]}
+		}
+		for i, ask := range asks {
+			data["asks"].([]interface{})[i] = []interface{}{ask[0], ask[1]}
+		}
+		return coincheck.OrderBookUpdate{"btc_jpy", data}
+	}
+
+	tests := []struct {
+		name          string
+		orderBook     coincheck.OrderBookUpdate
+		levels        []int
+		expected      obi.OBIResult
+		expectError   bool
+		checkTimeZero bool // True if we expect the timestamp to be the zero value of time.Time
+	}{
+		{
+			name:      "Empty Order Book",
+			orderBook: newOrderBookUpdate([][]string{}, [][]string{}, "1678886400"), // Empty bids and asks
+			levels:    []int{8, 16},
+			expected: obi.OBIResult{
+				OBI8:      0,
+				OBI16:     0,
+				Timestamp: time.Unix(1678886400, 0),
+			},
+			expectError: false,
+		},
+		{
+			name: "Bids Only",
+			orderBook: newOrderBookUpdate(
+				[][]string{{"100", "10"}, {"99", "5"}}, // Bids
+				[][]string{}, // Empty asks
+				"1678886401",
+			),
+			levels: []int{8, 16},
+			expected: obi.OBIResult{
+				OBI8:      1, // (10+5 - 0) / (10+5 + 0) = 1
+				OBI16:     1,
+				Timestamp: time.Unix(1678886401, 0),
+			},
+			expectError: false,
+		},
+		{
+			name: "Asks Only",
+			orderBook: newOrderBookUpdate(
+				[][]string{}, // Empty bids
+				[][]string{{"101", "8"}, {"102", "7"}}, // Asks
+				"1678886402",
+			),
+			levels: []int{8, 16},
+			expected: obi.OBIResult{
+				OBI8:      -1, // (0 - (8+7)) / (0 + (8+7)) = -1
+				OBI16:     -1,
+				Timestamp: time.Unix(1678886402, 0),
+			},
+			expectError: false,
+		},
+		{
+			name: "Balanced Order Book - Full Levels",
+			orderBook: newOrderBookUpdate(
+				[][]string{
+					{"100", "10"}, {"99", "5"}, {"98", "3"}, {"97", "2"},
+					{"96", "1"}, {"95", "1"}, {"94", "1"}, {"93", "1"}, // 8 bids
+				},
+				[][]string{
+					{"101", "10"}, {"102", "5"}, {"103", "3"}, {"104", "2"},
+					{"105", "1"}, {"106", "1"}, {"107", "1"}, {"108", "1"}, // 8 asks
+				},
+				"1678886403",
+			),
+			levels: []int{8},
+			expected: obi.OBIResult{
+				OBI8:      0, // (24 - 24) / (24 + 24) = 0
+				Timestamp: time.Unix(1678886403, 0),
+			},
+			expectError: false,
+		},
+		{
+			name: "More Bids than Asks - OBI8 and OBI16",
+			orderBook: newOrderBookUpdate(
+				// 10 bids
+				[][]string{
+					{"100", "10"}, {"99", "5"}, {"98", "3"}, {"97", "2"},
+					{"96", "1"}, {"95", "1"}, {"94", "1"}, {"93", "1"},
+					{"92", "1"}, {"91", "1"},
+				},
+				// 5 asks
+				[][]string{
+					{"101", "2"}, {"102", "2"}, {"103", "2"}, {"104", "2"},
+					{"105", "2"},
+				},
+				"1678886404",
+			),
+			levels: []int{8, 16},
+			expected: obi.OBIResult{
+				// OBI8: Bids (10+5+3+2+1+1+1+1)=24, Asks (2+2+2+2+2)=10. (24-10)/(24+10) = 14/34
+				OBI8:      14.0 / 34.0,
+				// OBI16: Bids (10+5+3+2+1+1+1+1+1+1)=26, Asks (2+2+2+2+2)=10. (26-10)/(26+10) = 16/36
+				OBI16:     16.0 / 36.0,
+				Timestamp: time.Unix(1678886404, 0),
+			},
+			expectError: false,
+		},
+		{
+			name: "Fewer Bids/Asks than Levels",
+			orderBook: newOrderBookUpdate(
+				[][]string{{"100", "10"}}, // 1 bid
+				[][]string{{"101", "5"}},  // 1 ask
+				"1678886405",
+			),
+			levels: []int{8, 16},
+			expected: obi.OBIResult{
+				OBI8:      (10.0 - 5.0) / (10.0 + 5.0), // (10-5)/(10+5) = 5/15
+				OBI16:     (10.0 - 5.0) / (10.0 + 5.0), // (10-5)/(10+5) = 5/15
+				Timestamp: time.Unix(1678886405, 0),
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid Data Format - Malformed OrderBookUpdate",
+			// Pass a deliberately malformed structure, e.g., not enough elements
+			orderBook:     coincheck.OrderBookUpdate{"btc_jpy"}, // Missing the data map
+			levels:        []int{8, 16},
+			expected:      obi.OBIResult{}, // Expect zero OBIResult
+			expectError:   false,           // CalculateOBI currently returns nil error and zero OBIResult
+			checkTimeZero: true,            // Expect timestamp to be zero because data extraction fails
+		},
+		{
+			name: "Invalid LastUpdateAt",
+			orderBook: newOrderBookUpdate(
+				[][]string{{"100", "10"}},
+				[][]string{{"101", "5"}},
+				"invalid-timestamp", // Invalid timestamp string
+			),
+			levels: []int{8, 16},
+			expected: obi.OBIResult{ // OBI values should still be calculated
+				OBI8:  (10.0 - 5.0) / (10.0 + 5.0),
+				OBI16: (10.0 - 5.0) / (10.0 + 5.0),
+				// Timestamp will be time.Now(), so we can't directly compare it.
+				// We'll check its non-zero value separately.
+			},
+			expectError: false,
+		},
+		{
+            name: "Zero amounts in book levels",
+            orderBook: newOrderBookUpdate(
+                [][]string{{"100", "10"}, {"99", "0"}}, // Bid with zero amount
+                [][]string{{"101", "5"}, {"102", "0"}}, // Ask with zero amount
+                "1678886406",
+            ),
+            levels: []int{8, 16},
+            expected: obi.OBIResult{
+                OBI8:      (10.0 - 5.0) / (10.0 + 5.0), // Zero amounts should be ignored
+                OBI16:     (10.0 - 5.0) / (10.0 + 5.0),
+                Timestamp: time.Unix(1678886406, 0),
+            },
+            expectError: false,
+        },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := obi.CalculateOBI(tt.orderBook, tt.levels...)
+
+			if (err != nil) != tt.expectError {
+				t.Errorf("CalculateOBI() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+
+			// For the "Invalid LastUpdateAt" case, we check if the timestamp is recent
+			// instead of comparing to a fixed expected timestamp.
+			if tt.name == "Invalid LastUpdateAt" {
+				if time.Since(actual.Timestamp) > 5*time.Second { // Allow some slack
+					t.Errorf("Expected a recent timestamp for invalid LastUpdateAt, got %v", actual.Timestamp)
+				}
+				// Set actual.Timestamp to expected.Timestamp for the rest of the comparison
+				// Or, better, create a copy of expected and set its timestamp to actual's
+				expectedCopy := tt.expected
+				expectedCopy.Timestamp = actual.Timestamp
+				if !cmp.Equal(expectedCopy, actual, cmpopts.EquateApprox(0.000001, 0)) {
+					t.Errorf("CalculateOBI() got = %v, want %v, diff: %s", actual, expectedCopy, cmp.Diff(expectedCopy, actual, cmpopts.EquateApprox(0.000001, 0)))
+				}
+			} else if tt.checkTimeZero {
+				if !actual.Timestamp.IsZero() {
+					t.Errorf("Expected Timestamp to be zero, got %v", actual.Timestamp)
+				}
+				// Compare other fields
+				expectedCopy := tt.expected
+				expectedCopy.Timestamp = actual.Timestamp // Match the (zero) timestamp for comparison
+				if !cmp.Equal(expectedCopy, actual, cmpopts.EquateApprox(0.000001, 0)) {
+                    t.Errorf("CalculateOBI() got = %v, want %v, diff: %s", actual, expectedCopy, cmp.Diff(expectedCopy, actual, cmpopts.EquateApprox(0.000001, 0)))
+                }
+			} else {
+				if !cmp.Equal(tt.expected, actual, cmpopts.EquateApprox(0.000001, 0)) {
+					t.Errorf("CalculateOBI() got = %v, want %v, diff: %s", actual, tt.expected, cmp.Diff(tt.expected, actual, cmpopts.EquateApprox(0.000001, 0)))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces the functionality to process L2 order book updates from Coincheck and calculate Order Book Imbalance (OBI) for 8 and 16 levels.

Key changes:
- Defined data structures for OrderBookUpdate and BookLevel in `internal/exchange/coincheck/types.go`.
- Implemented OBI calculation logic, including heap-based top N level aggregation, in `pkg/obi/obi.go`.
- Added comprehensive unit tests for OBI calculation in `pkg/obi/obi_test.go`, ensuring theoretical values match calculated results.
- Ensured CI checks (go vet, golangci-lint) pass.