### PR TITLE
fix(replay): リプレイ実行時に正しい設定ファイルが読み込まれるように修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ replay: ## Run a backtest using historical data.
 	@echo "Starting replay..."
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
-	@echo "Running replay task..."
-	docker-compose run --rm bot ./obi-scalp-bot -replay -config config/config-replay.yaml
+	@echo "Running replay task with override config..."
+	docker-compose -f docker-compose.yml -f docker-compose.replay.yml run --rm bot
 
 # ==============================================================================
 # GO BUILDS & TESTS

--- a/docker-compose.replay.yml
+++ b/docker-compose.replay.yml
@@ -1,0 +1,18 @@
+# docker-compose.replay.yml
+#
+# This file is used to override the default docker-compose.yml for replay mode.
+# It changes the command for the bot service to run the replay and
+# mounts the correct replay configuration file.
+
+services:
+  bot:
+    volumes:
+      # Unset the default config.yaml mount
+      - /dev/null:/app/config/config.yaml
+      # Mount the replay config file instead
+      - ./config/config-replay.yaml:/app/config/config-replay.yaml:ro
+    command: ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
+    # In replay mode, we don't need a healthcheck as it's a short-lived task
+    healthcheck:
+      disable: true
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   bot:
     build:


### PR DESCRIPTION
`make replay` を実行した際に、リプレイ用の設定ファイル (`config-replay.yaml`) ではなく、本番用の設定ファイル (`config.yaml`) が読み込まれてしまう問題を修正しました。

- リプレイ専用の `docker-compose.replay.yml` を作成し、コマンドと設定ファイルのマウントを上書きするようにした。
- `Makefile` の `replay` ターゲットが、`docker-compose.yml` と `docker-compose.replay.yml` の両方を使用するように修正。
- `docker-compose.yml` から不要な `version` 属性を削除。