### PR TITLE
fix(replay)!: リプレイ実行時の設定ファイル読み込みを確実化

### DIFF
--- a/docker-compose.replay.yml
+++ b/docker-compose.replay.yml
@@ -1,18 +1,14 @@
 # docker-compose.replay.yml
 #
-# This file is used to override the default docker-compose.yml for replay mode.
-# It changes the command for the bot service to run the replay and
-# mounts the correct replay configuration file.
+# Overrides for replay mode.
+# This file specifies the command to run the bot in replay mode and
+# ensures the correct configuration file is used.
 
 services:
   bot:
-    volumes:
-      # Unset the default config.yaml mount
-      - /dev/null:/app/config/config.yaml
-      # Mount the replay config file instead
-      - ./config/config-replay.yaml:/app/config/config-replay.yaml:ro
+    # The main docker-compose.yml already mounts the entire ./config directory.
+    # We just need to override the command to point to the correct file and add the -replay flag.
     command: ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
-    # In replay mode, we don't need a healthcheck as it's a short-lived task
     healthcheck:
       disable: true
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,11 @@ services:
       dockerfile: Dockerfile
     container_name: obi-scalp-bot
     volumes:
-      # Mount the local .env file into the container.
-      # Create a .env file from .env.sample and fill in your API keys.
       - ./.env:/app/.env:ro
-      # Mount the local config file into the container for easier development.
-      # Changes to config.yaml on the host will be reflected in the container without rebuilding.
-      - ./config/config.yaml:/app/config/config.yaml:ro
+      - ./config:/app/config:ro
     env_file:
-      - .env # Loads environment variables from the .env file at the root of the project
+      - .env
+    command: ./obi-scalp-bot -config /app/config/config.yaml
     environment:
       - DB_HOST=timescaledb
     ports:


### PR DESCRIPTION
`make replay` を実行した際に、リプレイ用の設定ファイルが読み込まれずにDBエラーが発生する問題を根本的に修正しました。

- `docker-compose.yml`:
  - `bot` サービスのボリュームマウントを、個別の設定ファイルから `config` ディレクトリ全体のマウントに変更。
  - デフォルトの起動コマンドを `command` で明示的に指定するように変更。
- `docker-compose.replay.yml`:
  - `command` を上書きし、`-replay` フラグと `config-replay.yaml` を指定するように修正。

この変更により、`docker-compose` の `command` 上書き機能を通じて、本番とリプレイの実行構成が確実かつ明確に分離されます。