### PR TITLE
Fix(replay): Load correct config file for replay mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm bot ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm bot -replay -config /app/config/config-replay.yaml
 
 # ==============================================================================
 # GO BUILDS & TESTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./.env:/app/.env:ro
       - ./config:/app/config:ro
+    entrypoint: ["./obi-scalp-bot"]
     env_file:
       - .env
     environment:


### PR DESCRIPTION
- Add entrypoint to docker-compose.yml to avoid command duplication.
- Modify Makefile's replay target to pass only arguments to the container.