### PR TITLE
fix: replayコマンドのエラーを修正し、リファクタリングを実施

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm bot ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
 
 # ==============================================================================
 # GO BUILDS & TESTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ./.env:/app/.env:ro
       - ./config:/app/config:ro
-    entrypoint: ["./obi-scalp-bot"]
+    command: ["./obi-scalp-bot", "-config", "/app/config/config.yaml"]
     env_file:
       - .env
     environment:


### PR DESCRIPTION
- `Makefile`の`replay`ターゲットで`docker-compose run`の引数を修正
- `docker-compose.yml`の`bot`サービスの`entrypoint`を`command`に変更
- `cmd/bot/main.go`をリファクタリングし、可読性を向上