### PR TITLE
I've made a couple of changes to fix an issue where the production co…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm bot ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm --entrypoint "" bot ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
 
 # ==============================================================================
 # GO BUILDS & TESTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     volumes:
       - ./.env:/app/.env:ro
       - ./config:/app/config:ro
-    command: ["./obi-scalp-bot", "-config", "/app/config/config.yaml"]
+    entrypoint: ["./obi-scalp-bot"]
+    command: ["-config", "/app/config/config.yaml"]
     env_file:
       - .env
     environment:


### PR DESCRIPTION
…nfig was being loaded during replay. I adjusted the `docker-compose.yml` to use `entrypoint` and `command` separately, and I updated the `replay` target in the `Makefile` to specify an `--entrypoint` for executing replay-specific commands.