### PR TITLE
fix: replayコマンドの実行エラーを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm --entrypoint "" bot ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm bot ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
 
 # ==============================================================================
 # GO BUILDS & TESTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     volumes:
       - ./.env:/app/.env:ro
       - ./config:/app/config:ro
-    entrypoint: ["./obi-scalp-bot"]
-    command: ["-config", "/app/config/config.yaml"]
+    command: ["./obi-scalp-bot", "-config", "/app/config/config.yaml"]
     env_file:
       - .env
     environment:


### PR DESCRIPTION
- `docker-compose.yml`の`command`と`Makefile`の`replay`ターゲットを修正し、`docker-compose run`でコマンドが正しく上書きされるようにしました