### PR TITLE
fix: replayコマンドの実行エラーを最終修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm bot ./obi-scalp-bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm bot -replay -config /app/config/config-replay.yaml
 
 # ==============================================================================
 # GO BUILDS & TESTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     volumes:
       - ./.env:/app/.env:ro
       - ./config:/app/config:ro
-    command: ["./obi-scalp-bot", "-config", "/app/config/config.yaml"]
+    entrypoint: ["./obi-scalp-bot"]
+    command: ["-config", "/app/config/config.yaml"]
     env_file:
       - .env
     environment:


### PR DESCRIPTION
- `docker-compose.yml`に`entrypoint`とデフォルト`command`を定義
- `Makefile`の`replay`ターゲットで`run`に引数を渡すことで`command`を上書きするように修正