### PR TITLE
修正完了：replayコマンドの実行エラーを修正しました。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm --entrypoint "./obi-scalp-bot -replay -config /app/config/config-replay.yaml" bot
 
 # ==============================================================================
 # GO BUILDS & TESTS


### PR DESCRIPTION
- `docker-compose.yml`にデフォルトのエントリポイントとコマンドを定義しました。
- `Makefile`のreplayターゲットで`--entrypoint`を使い、コマンドを完全に上書きすることで、引数の問題を解決しました。