### PR TITLE
I fixed a replay command execution error based on my analysis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm --entrypoint ./obi-scalp-bot bot -replay -config /app/config/config-replay.yaml
 
 # ==============================================================================
 # GO BUILDS & TESTS


### PR DESCRIPTION
- I kept `docker-compose.yml` on the stable version.
- In the `replay` target of the `Makefile`, I used `--entrypoint` correctly to completely overwrite the command, which solved the argument issue.