### PR TITLE
fix: replayコマンドの実行エラーをサービス分離で解決

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ replay: ## Run a backtest using historical data.
 	@echo "Ensuring monitoring services are running first..."
 	@make monitor
 	@echo "Running replay task..."
-	docker-compose run --rm --entrypoint ./obi-scalp-bot bot -replay -config /app/config/config-replay.yaml
+	docker-compose run --rm bot-replay
 
 # ==============================================================================
 # GO BUILDS & TESTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,24 @@ services:
     networks:
       - bot_network
 
+  bot-replay:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: obi-scalp-bot-replay
+    volumes:
+      - ./.env:/app/.env:ro
+      - ./config:/app/config:ro
+    command: ["./obi-scalp-bot", "-replay", "-config", "/app/config/config-replay.yaml"]
+    env_file:
+      - .env
+    environment:
+      - DB_HOST=timescaledb
+    depends_on:
+      - timescaledb
+    networks:
+      - bot_network
+
   timescaledb:
     image: timescale/timescaledb-ha:pg14-latest
     container_name: timescaledb-obi


### PR DESCRIPTION
- `docker-compose.yml`にreplay専用の`bot-replay`サービスを追加
- `Makefile`の`replay`ターゲットが`bot-replay`サービスを呼び出すように修正
- これにより、本番環境とリプレイ環境の実行を完全に分離し、引数の問題を根本的に解決