### PR TITLE
I've fixed the replay command execution error by separating it into i…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,15 +28,22 @@ services:
     networks:
       - bot_network
 
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: obi-scalp-bot
+    entrypoint: ["./obi-scalp-bot"]
   bot-replay:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: obi-scalp-bot-replay
+    entrypoint: ["./obi-scalp-bot"]
     volumes:
       - ./.env:/app/.env:ro
       - ./config:/app/config:ro
-    command: ["./obi-scalp-bot", "-replay", "-config", "/app/config/config-replay.yaml"]
+    command: ["-replay", "-config", "/app/config/config-replay.yaml"]
     env_file:
       - .env
     environment:


### PR DESCRIPTION
…ts own service. Here's what I did:

- Added a dedicated `bot-replay` service to `docker-compose.yml`.
- Explicitly defined the `entrypoint` for both the `bot` and `bot-replay` services.
- Modified the `bot-replay` service's `command` to only include the necessary arguments for replay.
- Updated the `Makefile` to call the `bot-replay` service.