### PR TITLE
fix: リプレイモードでのpanicとDB初期化の問題を修正

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -41,10 +41,7 @@ func main() {
 		startHealthCheckServer()
 	}
 
-	var dbWriter *dbwriter.Writer
-	if !f.replayMode {
-		dbWriter = setupDBWriter(ctx, cfg)
-	}
+	dbWriter := setupDBWriter(ctx, cfg)
 	if dbWriter != nil {
 		defer dbWriter.Close()
 	}


### PR DESCRIPTION
リプレイモード実行時に `panic: non-positive interval for NewTicker` が発生する問題に対処しました。

原因は、リプレイモード時にDBライターが初期化されず、設定が読み込まれないまま `time.NewTicker` がゼロ値で呼び出されていたことでした。

- `cmd/bot/main.go` を修正し、リプレイモードでもDBライターを常に初期化するように変更。

これにより、以前修正したDB接続の問題と合わせて、リプレイモードが正常に動作することが期待されます。