### PR TITLE
Fix(config): 修正config-replay.yamlのキーとwriterのフォールバック

### DIFF
--- a/config/config-replay.yaml
+++ b/config/config-replay.yaml
@@ -62,7 +62,7 @@ db_writer:
 
   # 書き込み間隔 (秒)
   # `make replay` では高速にデータが処理されるため、この値はあまり影響しません。
-  batch_interval_seconds: 5
+  write_interval_seconds: 5
 
 # --- 戦略パラメータ ---
 #

--- a/internal/dbwriter/writer.go
+++ b/internal/dbwriter/writer.go
@@ -102,6 +102,16 @@ func NewWriter(ctx context.Context, dbConfig config.DatabaseConfig, writerConfig
 
 	// Only start the background writer if the pool is valid
 	if writer.pool != nil {
+		// Fallback for zero or invalid values
+		if writerConfig.WriteIntervalSeconds <= 0 {
+			writerConfig.WriteIntervalSeconds = 1 // Default to 1s to avoid panic
+			logger.Warn("WriteIntervalSeconds is zero or negative, defaulting to 1s.", zap.Int("originalValue", writerConfig.WriteIntervalSeconds))
+		}
+		if writer.config.BatchSize <= 0 {
+			writer.config.BatchSize = 100 // Default to 100 to avoid issues
+			logger.Warn("BatchSize is zero or negative, defaulting to 100.", zap.Int("originalValue", writer.config.BatchSize))
+		}
+
 		batchInterval := time.Duration(writerConfig.WriteIntervalSeconds) * time.Second
 		writer.flushTicker = time.NewTicker(batchInterval)
 		go writer.run()


### PR DESCRIPTION
- `config-replay.yaml` の `batch_interval_seconds` を `write_interval_seconds` に修正
- `internal/dbwriter/writer.go` に `WriteIntervalSeconds` が0以下の場合のフォールバック処理を追加