### PR TITLE
Fix: Replay mode fails to load market events

### DIFF
--- a/internal/datastore/repository.go
+++ b/internal/datastore/repository.go
@@ -117,7 +117,7 @@ func (r *Repository) fetchOrderBookUpdates(ctx context.Context, pair string, sta
 	query := `
         SELECT time, side, price, size
         FROM order_book_updates
-        WHERE pair = $1 AND time >= $2 AND time < $3 AND is_snapshot = TRUE
+        WHERE pair = $1 AND time >= $2 AND time < $3
         ORDER BY time ASC;
     `
 	// This query is likely insufficient for a proper backtest.


### PR DESCRIPTION
This commit resolves an issue where the replay mode would not load any market events from the database.

The root cause was that the `fetchOrderBookUpdates` function in the repository was filtering for snapshot data (`is_snapshot = TRUE`) only, while the database contained only differential update data (`is_snapshot = FALSE`).

The fix involves removing the `is_snapshot = TRUE` condition from the SQL query, allowing the replay mode to correctly fetch all order book updates within the specified time range.