### PR TITLE
feat(debug): WebSocket受信メッセージのデバッグログを追加

### DIFF
--- a/internal/exchange/coincheck/websocket.go
+++ b/internal/exchange/coincheck/websocket.go
@@ -107,6 +107,7 @@ func (c *WebSocketClient) Connect() error {
 				}
 				return
 			}
+			logger.Debugf("Received raw message: %s", string(message)) // Raw message logging
 
 			// Handle trades message (different format)
 			var rawTradeData []string
@@ -195,7 +196,7 @@ func (c *WebSocketClient) Connect() error {
 
 type subscriptionMessage struct {
 	Type    string `json:"type"`
-	Channel string `json:"json"`
+	Channel string `json:"channel"`
 }
 
 func (c *WebSocketClient) subscribe(channel string) error {


### PR DESCRIPTION
DBにデータが書き込まれない問題の調査のため、internal/exchange/coincheck/websocket.go に、受信したWebSocketの生メッセージをログ出力する機能を追加しました。

また、購読メッセージの構造体のJSONタグが誤っていたため、`json:"json"` から
`json:"channel"` に修正しました。