### PR TITLE
feat(debug): orderBookHandlerに詳細なデバッグログを追加

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -133,9 +133,12 @@ func setupDBWriter(ctx context.Context, cfg *config.Config) *dbwriter.Writer {
 // setupHandlers creates and returns the handlers for order book and trade data.
 func setupHandlers(orderBook *indicator.OrderBook, dbWriter *dbwriter.Writer, pair string) (coincheck.OrderBookHandler, coincheck.TradeHandler) {
 	orderBookHandler := func(data coincheck.OrderBookData) {
+		logger.Debugf("orderBookHandler: received data")
 		orderBook.ApplyUpdate(data)
+		logger.Debugf("orderBookHandler: applied update to in-memory book")
 
 		if dbWriter == nil {
+			logger.Debugf("orderBookHandler: dbWriter is nil, skipping DB write")
 			return
 		}
 
@@ -143,7 +146,8 @@ func setupHandlers(orderBook *indicator.OrderBook, dbWriter *dbwriter.Writer, pa
 
 		// Helper function to parse and save levels
 		saveLevels := func(levels [][]string, side string, isSnapshot bool) {
-			for _, level := range levels {
+			logger.Debugf("orderBookHandler: saveLevels started for side %s", side)
+			for i, level := range levels {
 				price, err := strconv.ParseFloat(level[0], 64)
 				if err != nil {
 					logger.Errorf("Failed to parse order book price: %v", err)
@@ -163,12 +167,15 @@ func setupHandlers(orderBook *indicator.OrderBook, dbWriter *dbwriter.Writer, pa
 					IsSnapshot: isSnapshot,
 				}
 				dbWriter.SaveOrderBookUpdate(update)
+				logger.Debugf("orderBookHandler: saved level %d for side %s", i, side)
 			}
+			logger.Debugf("orderBookHandler: saveLevels finished for side %s", side)
 		}
 
 		// For Coincheck, each update is a snapshot
 		saveLevels(data.Bids, "bid", true)
 		saveLevels(data.Asks, "ask", true)
+		logger.Debugf("orderBookHandler: finished processing")
 	}
 
 	tradeHandler := func(data coincheck.TradeData) {


### PR DESCRIPTION
order_book_updatesテーブルへの書き込みがされない問題の調査のため、
`cmd/bot/main.go`の`orderBookHandler`関数内の各処理ステップで
詳細なデバッグログを出力するようにしました。

これにより、処理が停止する正確な箇所を特定し、デッドロック等の
問題を診断します。