### PR TITLE
feat: 損益分析レポートにJSON出力と集計期間を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,8 @@ build: ## Build the Go application binary inside the container.
 	@echo "Building Go application binary..."
 	@mkdir -p build
 	$(DOCKER_RUN_GO) go build -a -ldflags="-s -w" -o build/obi-scalp-bot cmd/bot/main.go
+
+report: ## Build the report generation script.
+	@echo "Building report generation script..."
+	@mkdir -p build
+	$(DOCKER_RUN_GO) go build -o build/report cmd/report/main.go

--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Trade はデータベースからの取引を表します。
+type Trade struct {
+	Time          time.Time       `json:"time"`
+	Pair          string          `json:"pair"`
+	Side          string          `json:"side"`
+	Price         decimal.Decimal `json:"price"`
+	Size          decimal.Decimal `json:"size"`
+	TransactionID int64           `json:"transaction_id"`
+}
+
+func main() {
+	// 環境変数からデータベース接続情報を取得
+	dbHost := os.Getenv("DB_HOST")
+	dbPortStr := os.Getenv("DB_PORT")
+	dbUser := os.Getenv("DB_USER")
+	dbPassword := os.Getenv("DB_PASSWORD")
+	dbName := os.Getenv("DB_NAME")
+
+	if dbHost == "" || dbPortStr == "" || dbUser == "" || dbPassword == "" || dbName == "" {
+		fmt.Fprintln(os.Stderr, "Database environment variables are not set.")
+		os.Exit(1)
+	}
+
+	dbPort, err := strconv.Atoi(dbPortStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid DB_PORT: %v\n", err)
+		os.Exit(1)
+	}
+
+	// データベース接続
+	connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		dbUser, dbPassword, dbHost, dbPort, dbName)
+	dbpool, err := pgxpool.New(context.Background(), connStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to connect to database: %v\n", err)
+		os.Exit(1)
+	}
+	defer dbpool.Close()
+
+	// すべてのトレードを取得
+	trades, err := fetchAllTrades(context.Background(), dbpool)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching trades: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(trades) == 0 {
+		fmt.Println("No trades found.")
+		return
+	}
+
+	// 損益分析
+	report, err := analyzeTrades(trades)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error analyzing trades: %v\n", err)
+		os.Exit(1)
+	}
+
+	// レポートをコンソールに出力
+	printReport(report)
+
+	// レポートをJSONファイルに出力
+	if err := writeReportToJSON(report, "report.json"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing JSON report: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Report successfully written to report.json")
+}
+
+// fetchAllTrades はデータベースからすべてのトレードを取得します。
+func fetchAllTrades(ctx context.Context, dbpool *pgxpool.Pool) ([]Trade, error) {
+	query := `
+        SELECT time, pair, side, price, size, transaction_id
+        FROM trades
+        ORDER BY time ASC;
+    `
+	rows, err := dbpool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var trades []Trade
+	for rows.Next() {
+		var t Trade
+		if err := rows.Scan(&t.Time, &t.Pair, &t.Side, &t.Price, &t.Size, &t.TransactionID); err != nil {
+			return nil, err
+		}
+		trades = append(trades, t)
+	}
+
+	return trades, rows.Err()
+}
+
+// Report は損益分析の結果を保持します。
+type Report struct {
+	StartDate       time.Time       `json:"start_date"`
+	EndDate         time.Time       `json:"end_date"`
+	TotalTrades     int             `json:"total_trades"`
+	WinningTrades   int             `json:"winning_trades"`
+	LosingTrades    int             `json:"losing_trades"`
+	WinRate         float64         `json:"win_rate"`
+	TotalPnL        decimal.Decimal `json:"total_pnl"`
+	AverageProfit   decimal.Decimal `json:"average_profit"`
+	AverageLoss     decimal.Decimal `json:"average_loss"`
+	RiskRewardRatio float64         `json:"risk_reward_ratio"`
+}
+
+// analyzeTrades はトレードリストを分析してレポートを作成します。
+func analyzeTrades(trades []Trade) (Report, error) {
+	if len(trades) == 0 {
+		return Report{}, fmt.Errorf("no trades to analyze")
+	}
+
+	var buys []Trade
+	var totalPnL decimal.Decimal
+	var winningTrades, losingTrades int
+	var totalProfit, totalLoss decimal.Decimal
+
+	startDate := trades[0].Time
+	endDate := trades[len(trades)-1].Time
+
+	for _, trade := range trades {
+		if trade.Side == "buy" {
+			buys = append(buys, trade)
+		} else if trade.Side == "sell" {
+			sellSize := trade.Size
+			for len(buys) > 0 && sellSize.IsPositive() {
+				buy := buys[0]
+				matchSize := decimal.Min(buy.Size, sellSize)
+
+				pnl := trade.Price.Sub(buy.Price).Mul(matchSize)
+				totalPnL = totalPnL.Add(pnl)
+
+				if pnl.IsPositive() {
+					winningTrades++
+					totalProfit = totalProfit.Add(pnl)
+				} else {
+					losingTrades++
+					totalLoss = totalLoss.Add(pnl.Abs())
+				}
+
+				buy.Size = buy.Size.Sub(matchSize)
+				sellSize = sellSize.Sub(matchSize)
+
+				if buy.Size.IsZero() {
+					buys = buys[1:]
+				} else {
+					buys[0] = buy
+				}
+			}
+		}
+	}
+
+	totalTrades := winningTrades + losingTrades
+	winRate := 0.0
+	if totalTrades > 0 {
+		winRate = float64(winningTrades) / float64(totalTrades) * 100
+	}
+
+	avgProfit := decimal.Zero
+	if winningTrades > 0 {
+		avgProfit = totalProfit.Div(decimal.NewFromInt(int64(winningTrades)))
+	}
+
+	avgLoss := decimal.Zero
+	if losingTrades > 0 {
+		avgLoss = totalLoss.Div(decimal.NewFromInt(int64(losingTrades)))
+	}
+
+	riskRewardRatio := 0.0
+	if !avgLoss.IsZero() {
+		riskRewardRatio = avgProfit.Div(avgLoss).InexactFloat64()
+	}
+
+	return Report{
+		StartDate:       startDate,
+		EndDate:         endDate,
+		TotalTrades:     totalTrades,
+		WinningTrades:   winningTrades,
+		LosingTrades:    losingTrades,
+		WinRate:         winRate,
+		TotalPnL:        totalPnL,
+		AverageProfit:   avgProfit,
+		AverageLoss:     avgLoss,
+		RiskRewardRatio: riskRewardRatio,
+	}, nil
+}
+
+// printReport は分析レポートをコンソールに出力します。
+func printReport(r Report) {
+	fmt.Println("--- 損益分析レポート ---")
+	fmt.Printf("集計期間: %s から %s\n", r.StartDate.Format(time.RFC3339), r.EndDate.Format(time.RFC3339))
+	fmt.Printf("総取引回数: %d\n", r.TotalTrades)
+	fmt.Printf("勝ちトレード数: %d\n", r.WinningTrades)
+	fmt.Printf("負けトレード数: %d\n", r.LosingTrades)
+	fmt.Printf("勝率: %.2f%%\n", r.WinRate)
+	fmt.Printf("合計損益: %s\n", r.TotalPnL.StringFixed(2))
+	fmt.Printf("平均利益: %s\n", r.AverageProfit.StringFixed(2))
+	fmt.Printf("平均損失: %s\n", r.AverageLoss.StringFixed(2))
+	fmt.Printf("リスクリワードレシオ: %.2f\n", r.RiskRewardRatio)
+	fmt.Println("----------------------")
+}
+
+// writeReportToJSON はレポートをJSONファイルに書き込みます。
+func writeReportToJSON(r Report, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(r)
+}


### PR DESCRIPTION
- 損益分析レポートをJSON形式でファイルに出力する機能を追加
- レポートに取引データの集計期間（開始日時と終了日時）を含めるように修正