### PR TITLE
Feat: Add PnL calculation and saving

### DIFF
--- a/internal/pnl/pnl.go
+++ b/internal/pnl/pnl.go
@@ -1,0 +1,38 @@
+package pnl
+
+import (
+	"sync"
+)
+
+// Calculator handles PnL calculations.
+type Calculator struct {
+	RealizedPnL   float64
+	mutex         sync.RWMutex
+}
+
+// NewCalculator creates a new PnL Calculator.
+func NewCalculator() *Calculator {
+	return &Calculator{}
+}
+
+// UpdateRealizedPnL updates the realized PnL.
+func (c *Calculator) UpdateRealizedPnL(pnl float64) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.RealizedPnL += pnl
+}
+
+// CalculateUnrealizedPnL calculates the unrealized PnL.
+func (c *Calculator) CalculateUnrealizedPnL(positionSize float64, avgEntryPrice float64, currentPrice float64) float64 {
+	if positionSize == 0 {
+		return 0
+	}
+	return (currentPrice - avgEntryPrice) * positionSize
+}
+
+// GetRealizedPnL returns the current realized PnL.
+func (c *Calculator) GetRealizedPnL() float64 {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.RealizedPnL
+}

--- a/internal/position/position.go
+++ b/internal/position/position.go
@@ -1,0 +1,55 @@
+package position
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Position holds the state of a trading position.
+type Position struct {
+	Size           float64
+	AvgEntryPrice  float64
+	mutex          sync.RWMutex
+}
+
+// NewPosition creates a new Position instance.
+func NewPosition() *Position {
+	return &Position{}
+}
+
+// Update updates the position based on a trade.
+func (p *Position) Update(tradeSize float64, tradePrice float64) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	// current total value of the position
+	currentValue := p.Size * p.AvgEntryPrice
+	// value of the new trade
+	tradeValue := tradeSize * tradePrice
+
+	// new total size of the position
+	newSize := p.Size + tradeSize
+
+	if newSize == 0 {
+		p.AvgEntryPrice = 0
+	} else {
+		// new average entry price
+		p.AvgEntryPrice = (currentValue + tradeValue) / newSize
+	}
+
+	p.Size = newSize
+}
+
+// Get returns the current size and average entry price of the position.
+func (p *Position) Get() (float64, float64) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	return p.Size, p.AvgEntryPrice
+}
+
+// String returns a string representation of the position.
+func (p *Position) String() string {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	return fmt.Sprintf("Position{Size: %.4f, AvgEntryPrice: %.2f}", p.Size, p.AvgEntryPrice)
+}


### PR DESCRIPTION
This commit introduces PnL calculation and saving to the replay execution engine.

- Created a new `position` package to manage the bot's position.
- Created a new `pnl` package to calculate PnL.
- Integrated the new packages into the `ReplayExecutionEngine`.
- Added a call to save the PnL data to the database.