### PR TITLE
fix(export): Explicitly pass env_file to docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ export-sim-data: ## Export order book data from the database to a CSV file for s
 	fi
 	@FILENAME="simulation/order_book_updates_$$(date +%Y%m%d-%H%M%S).csv"; \
 	echo "Exporting data to $$FILENAME..."; \
-	sudo -E docker compose run --rm builder go run cmd/export/main.go --start "$(START_TIME)" --end "$(END_TIME)" > $$FILENAME
+	sudo -E docker compose --env-file ./.env run --rm builder go run cmd/export/main.go --start "$(START_TIME)" --end "$(END_TIME)" > $$FILENAME
 	@echo "Export complete. See $$FILENAME";
 
 # ==============================================================================


### PR DESCRIPTION
The `export-sim-data` command was failing with a password authentication error because the environment variables from the .env file (specifically `DB_USER` and `DB_PASSWORD`) were not being correctly passed to the `builder` container during the `docker compose run` execution.

This commit fixes the issue by explicitly adding the `--env-file ./.env` flag to the `docker compose run` command in the Makefile. This ensures that the Go export script running inside the `builder` container receives the necessary database credentials to authenticate successfully.