### PR TITLE
feat: 残高確認と注文ロジックのログを改善

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -291,6 +291,13 @@ func runMainLoop(ctx context.Context, f flags, cfg *config.Config, dbWriter *dbw
 		}
 		logger.Infof("Initial balance: JPY=%.2f, BTC=%.8f", availableJpy, availableBtc)
 
+		if availableJpy <= 0 {
+			logger.Warnf("Available JPY balance is %.2f. Trading may be limited.", availableJpy)
+		}
+		if availableBtc <= 0 {
+			logger.Warnf("Available BTC balance is %.8f. Selling will not be possible.", availableBtc)
+		}
+
 		execEngine := engine.NewLiveExecutionEngine(client, availableJpy, availableBtc)
 
 		orderBook := indicator.NewOrderBook()

--- a/internal/engine/execution_engine.go
+++ b/internal/engine/execution_engine.go
@@ -59,7 +59,7 @@ func (e *LiveExecutionEngine) PlaceOrder(ctx context.Context, pair string, order
 	} else if orderType == "sell" {
 		if amount > e.availableBtc {
 			adjustedAmount = e.availableBtc
-			logger.Warnf("[Live] Sell order amount %.8f exceeds available BTC balance. Adjusting to %.8f.", amount, adjustedAmount)
+			logger.Warnf("[Live] Sell order amount %.8f exceeds available BTC balance (%.8f). Adjusting to %.8f.", amount, e.availableBtc, adjustedAmount)
 		}
 	}
 

--- a/internal/exchange/coincheck/order.go
+++ b/internal/exchange/coincheck/order.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/your-org/obi-scalp-bot/pkg/logger"
 	// "github.com/google/uuid" // No longer used after removing newNonce
 )
 
@@ -190,6 +192,10 @@ func (c *Client) GetBalance() (*BalanceResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read get balance response body (status: %d): %w", resp.StatusCode, err)
 	}
+
+	// Log the raw response body for debugging purposes.
+	// This helps verify the structure and content of the data received from Coincheck.
+	logger.Debugf("GetBalance response body: %s", string(bodyBytes))
 
 	var balanceResp BalanceResponse
 	if err := json.Unmarshal(bodyBytes, &balanceResp); err != nil {


### PR DESCRIPTION
- 注文失敗の原因調査を容易にするため、デバッグログを追加・改善
- Coincheck APIからの残高取得時にレスポンスボディをデバッグログに出力するようにした
- ボット起動時に利用可能な残高が0の場合、警告ログを出力するようにした
- BTC残高不足で売り注文が調整される際の警告ログに、調整前の利用可能残高も表示するようにした