### PR TITLE
fix(make): reportターゲットを.PHONYに追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: help up down logs shell clean test build replay monitor
+.PHONY: help up down logs shell clean test build replay monitor report
 
 # ==============================================================================
 # HELP


### PR DESCRIPTION
`make report`を実行した際に、`cmd/report`ディレクトリが存在すると`make: 'report' is up to date.`というメッセージが表示され、コマンドが実行されない問題がありました。

`report`ターゲットを`.PHONY`に追加することで、makeがファイルシステムのオブジェクトとターゲット名を関連付けることを防ぎ、常にコマンドが実行されるように修正しました。