### PR TITLE
Fix bug where order price could be halved

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -238,6 +238,10 @@ func processSignalsAndExecute(ctx context.Context, cfg *config.Config, obiCalcul
 				logger.Info("Signal processing and execution goroutine shutting down.")
 				return
 			case result := <-resultsCh:
+				if result.BestBid <= 0 || result.BestAsk <= 0 {
+					logger.Warnf("Skipping signal evaluation due to invalid best bid/ask: BestBid=%.2f, BestAsk=%.2f", result.BestBid, result.BestAsk)
+					continue
+				}
 				// TODO: This is a simplified view. We need more data for a robust signal.
 				// For now, we use a placeholder for mid-price and other data points.
 				// A proper implementation would get this from the order book.

--- a/internal/indicator/obi.go
+++ b/internal/indicator/obi.go
@@ -64,13 +64,14 @@ func (c *OBICalculator) Start(ctx context.Context) {
 				c.orderBook.RUnlock()
 
 				if isBookReady {
-					obiResult := c.orderBook.CalculateOBI(OBILevels...)
-					// Non-blocking send
-					select {
-					case c.output <- obiResult:
-					default:
-						// If the channel is full, the previous value will be overwritten.
-						// This is often acceptable for real-time indicators where the latest value is most important.
+					if obiResult, ok := c.orderBook.CalculateOBI(OBILevels...); ok {
+						// Non-blocking send
+						select {
+						case c.output <- obiResult:
+						default:
+							// If the channel is full, the previous value will be overwritten.
+							// This is often acceptable for real-time indicators where the latest value is most important.
+						}
 					}
 				}
 			case <-c.done:

--- a/internal/indicator/orderbook.go
+++ b/internal/indicator/orderbook.go
@@ -88,7 +88,7 @@ type priceLevel struct {
 }
 
 // CalculateOBI calculates the Order Book Imbalance from the current state of the book.
-func (ob *OrderBook) CalculateOBI(levels ...int) OBIResult {
+func (ob *OrderBook) CalculateOBI(levels ...int) (OBIResult, bool) {
 	ob.RLock()
 	defer ob.RUnlock()
 
@@ -117,12 +117,12 @@ func (ob *OrderBook) CalculateOBI(levels ...int) OBIResult {
 		return asks[i].Rate < asks[j].Rate
 	})
 
-	if len(bids) > 0 {
-		result.BestBid = bids[0].Rate
+	if len(bids) == 0 || len(asks) == 0 {
+		return OBIResult{}, false
 	}
-	if len(asks) > 0 {
-		result.BestAsk = asks[0].Rate
-	}
+
+	result.BestBid = bids[0].Rate
+	result.BestAsk = asks[0].Rate
 
 	maxLevel := 0
 	for _, l := range levels {
@@ -167,5 +167,5 @@ func (ob *OrderBook) CalculateOBI(levels ...int) OBIResult {
 		}
 	}
 
-	return result
+	return result, true
 }


### PR DESCRIPTION
The `midPrice` was calculated without ensuring that both `BestBid` and `BestAsk` were present. If one of them was missing (zero value), the `midPrice` would be incorrect, leading to orders at half the expected price.

This fix ensures that `OBIResult` is only generated and used when both `BestBid` and `BestAsk` are valid, preventing the calculation of an incorrect `midPrice`.