### PR TITLE
feat: ロング/ショート戦略別の勝率分析機能を追加

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,12 @@ require (
 )
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/shopspring/decimal v1.4.0
 )
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect


### PR DESCRIPTION
`make report` の出力に、ロング戦略とショート戦略それぞれの勝率、勝ちトレード数、負けトレード数を追加しました。

- `Report` 構造体を拡張して、新しい分析項目を格納できるようにしました。
- `analyzeTrades` 関数を修正し、ロングとショートのポジションを個別に追跡して、それぞれのパフォーマンスを計算するようにしました。
- `printReport` 関数を更新し、新しい分析結果をコンソールに分かりやすく表示するようにしました。