### PR TITLE
feat: config.yamlに日本語コメントと新規パラメータを追加

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,28 +1,87 @@
 # OBI-Scalp-Bot 設定ファイル (config.yaml)
-log_level: "info"
+
+# --- 戦略パラメータ ---
+# これらの値は、ボットの売買戦略に直接影響します。
+
+# 取引ペア
 pair: "btc_jpy"
+# 許容する最大スプレッド（円）
 spread_limit: 60
+# 1注文あたりの最大ロット比率（対利用可能残高）
 lot_max_ratio: 0.05
+# 注文比率
 order_ratio: 0.2
 
+# ロングエントリー戦略
 long:
+  # OBIの閾値
   obi_threshold: 0.40
+  # 利食い幅（円）
   tp: 25
+  # 損切り幅（円）
   sl: -10
 
+# ショートエントリー戦略
 short:
+  # OBIの閾値
   obi_threshold: -0.27
+  # 利食い幅（円）
   tp: 25
+  # 損切り幅（円）
   sl: -12
 
+# ボラティリティ設定
 volatility:
+  # EWMA（指数平滑移動平均）のλ値
   ewma_lambda: 0.3
+  # 動的OBI設定
   dynamic_obi:
+    # 有効化フラグ
     enabled: true
+    # ボラティリティ係数
     volatility_factor: 1.3
+    # 最小閾値係数
     min_threshold_factor: 0.7
+    # 最大閾値係数
     max_threshold_factor: 1.8
 
+# TWAP（時間加重平均価格）注文設定
+twap:
+  # 有効化フラグ
+  enabled: false
+  # 1注文あたりの最大サイズ（BTC）
+  max_order_size_btc: 0.01
+  # 注文間隔（秒）
+  interval_seconds: 10
+
+# シグナル設定
+signal:
+  # シグナル確定までの待機時間（ミリ秒）
+  # OBIが閾値を超えても即座にエントリーせず、この時間だけ閾値を超え続けた場合にシグナルが確定します。
+  # 値を大きくするとダマシを避けやすくなりますが、エントリーは遅れます。
+  # 値を小さくすると素早く反応できますが、ノイズに弱くなります。
+  hold_duration_ms: 300
+
+
+# --- アプリケーション設定 ---
+# ボットの動作、データベース接続、リプレイモードなど、システム全体に関わる設定です。
+
+# ログレベル ("debug", "info", "warn", "error")
+log_level: "info"
+
+# 注文執行エンジン設定
+order:
+  # 注文タイムアウト時間（秒）
+  # 指値注文がこの時間内に約定しない場合、自動的にキャンセルされます。
+  # 値を大きくすると約定の機会は増えますが、相場変動リスクも高まります。
+  # 値を小さくすると機会損失は減りますが、約定チャンスを逃す可能性もあります。
+  timeout_seconds: 30
+  # 注文状況確認のポーリング間隔（ミリ秒）
+  # 注文の約定状況を取引所に確認しにいく頻度です。
+  # 売買戦略には直接影響しませんが、APIリクエスト頻度に関わるため、短くしすぎないでください。
+  poll_interval_ms: 2000
+
+# データベース接続設定
 database:
   host: "timescaledb"
   port: 5432
@@ -31,16 +90,18 @@ database:
   name: "obi_scalp_bot_db"
   sslmode: "disable"
 
+# データベース書き込み設定
 db_writer:
+  # 一度に書き込むバッチサイズ
   batch_size: 100
+  # 書き込み間隔（秒）
   write_interval_seconds: 5
+  # 非同期書き込みの有効化
   enable_async: false
 
+# リプレイモード設定
 replay:
+  # 開始時刻 (RFC3339形式)
   start_time: "2025-07-13T00:00:00Z"
+  # 終了時刻 (RFC3339形式)
   end_time: "2025-07-14T00:00:00Z"
-
-twap:
-  enabled: false
-  max_order_size_btc: 0.01
-  interval_seconds: 10

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,20 +9,33 @@ import (
 
 // Config defines the structure for all application configuration.
 type Config struct {
-	Pair        string       `yaml:"pair"`
-	SpreadLimit float64      `yaml:"spread_limit"`
-	LotMaxRatio float64      `yaml:"lot_max_ratio"`
-	OrderRatio  float64      `yaml:"order_ratio"`
-	Long        StrategyConf `yaml:"long"`
-	Short       StrategyConf `yaml:"short"`
-	Volatility  VolConf      `yaml:"volatility"`
-	APIKey      string       `yaml:"-"` // Loaded from env
-	APISecret   string       `yaml:"-"` // Loaded from env
-	LogLevel    string       `yaml:"log_level"`
+	Pair        string         `yaml:"pair"`
+	SpreadLimit float64        `yaml:"spread_limit"`
+	LotMaxRatio float64        `yaml:"lot_max_ratio"`
+	OrderRatio  float64        `yaml:"order_ratio"`
+	Long        StrategyConf   `yaml:"long"`
+	Short       StrategyConf   `yaml:"short"`
+	Volatility  VolConf        `yaml:"volatility"`
+	Twap        TwapConfig     `yaml:"twap"`
+	Signal      SignalConfig   `yaml:"signal"`
+	APIKey      string         `yaml:"-"` // Loaded from env
+	APISecret   string         `yaml:"-"` // Loaded from env
+	LogLevel    string         `yaml:"log_level"`
+	Order       OrderConfig    `yaml:"order"`
 	Database    DatabaseConfig `yaml:"database"`
 	DBWriter    DBWriterConfig `yaml:"db_writer"`
-	Replay      ReplayConfig `yaml:"replay"`
-	Twap        TwapConfig   `yaml:"twap"`
+	Replay      ReplayConfig   `yaml:"replay"`
+}
+
+// SignalConfig holds configuration for signal generation.
+type SignalConfig struct {
+	HoldDurationMs int `yaml:"hold_duration_ms"`
+}
+
+// OrderConfig holds configuration for the execution engine.
+type OrderConfig struct {
+	TimeoutSeconds  int `yaml:"timeout_seconds"`
+	PollIntervalMs int `yaml:"poll_interval_ms"`
 }
 
 // TwapConfig holds configuration for the TWAP execution strategy.

--- a/internal/engine/execution_engine.go
+++ b/internal/engine/execution_engine.go
@@ -118,8 +118,8 @@ func (e *LiveExecutionEngine) PlaceOrder(ctx context.Context, pair string, order
 	logger.Infof("[Live] Order placed successfully: ID=%d", orderResp.ID)
 
 	// Monitor for execution
-	const pollInterval = 2 * time.Second
-	const timeout = 30 * time.Second
+	pollInterval := time.Duration(e.cfg.Order.PollIntervalMs) * time.Millisecond
+	timeout := time.Duration(e.cfg.Order.TimeoutSeconds) * time.Second
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -75,7 +75,7 @@ type SignalEngine struct {
 
 // NewSignalEngine creates a new SignalEngine.
 func NewSignalEngine(cfg *config.Config) (*SignalEngine, error) {
-	signalHoldDuration := 300 * time.Millisecond // Example, make configurable if needed
+	signalHoldDuration := time.Duration(cfg.Signal.HoldDurationMs) * time.Millisecond
 
 	engineCfg := EngineConfig{
 		LongOBIBaseThreshold:  cfg.Long.OBIThreshold,


### PR DESCRIPTION
config.yamlに各項目の説明を日本語でコメントとして追加し、戦略パラメータとアプリケーション設定に整理しました。

また、以下の戦略的パラメータを新たに追加し、ハードコーディングされていた値を置き換えました。

- `signal.hold_duration_ms`: シグナル確定までの待機時間
- `order.timeout_seconds`: 注文のタイムアウト時間
- `order.poll_interval_ms`: 注文状況のポーリング間隔