### PR TITLE
feat: Add make command to start Grafana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: help up down logs shell clean test build replay monitor report
+.PHONY: help up down logs shell clean test build replay monitor report grafana
 
 # ==============================================================================
 # HELP
@@ -27,6 +27,10 @@ up: ## Start all services including the bot for live trading.
 monitor: ## Start monitoring services (DB, Grafana) without the bot.
 	@echo "Starting monitoring services (TimescaleDB, Grafana)..."
 	sudo -E docker compose up -d timescaledb grafana
+
+grafana: ## Start only the Grafana service.
+	@echo "Starting Grafana service..."
+	sudo -E docker compose up -d grafana
 
 down: ## Stop and remove all application stack containers.
 	@echo "Stopping application stack..."


### PR DESCRIPTION
This commit adds a new `grafana` command to the `Makefile`. This command allows you to start the Grafana service independently by running `make grafana`.