### PR TITLE
fix: Pass DB credentials to Grafana via environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,12 +123,13 @@ services:
     container_name: grafana-obi
     ports:
       - "3000:3000"
-    env_file:
-      - .env
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - DB_USER=${DB_USER}
+      - DB_NAME=${DB_NAME}
+      - DB_PASSWORD=${DB_PASSWORD}
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro


### PR DESCRIPTION
- Removed `env_file` from the grafana service in docker-compose.yml.
- Explicitly passed `DB_USER`, `DB_NAME`, and `DB_PASSWORD` to the `environment` section.
- This ensures that the Grafana container receives the necessary credentials to connect to the database, resolving the variable expansion issue.