### PR TITLE
I have reverted the Grafana service configuration to use `env_file`.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,13 +123,12 @@ services:
     container_name: grafana-obi
     ports:
       - "3000:3000"
+    env_file:
+      - .env
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-      - DB_USER=${DB_USER}
-      - DB_NAME=${DB_NAME}
-      - DB_PASSWORD=${DB_PASSWORD}
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro


### PR DESCRIPTION
- Reverted the grafana service configuration in docker-compose.yml to use `env_file` instead of passing database credentials directly through the `environment` section.
- This aligns the configuration with other services in the file and is a more standard way to handle environment variables in Docker Compose.
- This is another attempt to resolve the issue of environment variables not being available in the Grafana container.