### PR TITLE
Fix: Resolve grafana-render command failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,9 @@
 # Build output
 build/
 .env
+
+# Local tools
+bin/
+vendor/
 pkg/cvd/test_trades.csv
 report_app

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ DASHBOARDS_DIR = $(GRAFANA_DIR)/dashboards
 JSONNET_DIR = $(GRAFANA_DIR)/jsonnet
 JSONNET_FILES = $(wildcard $(JSONNET_DIR)/*.jsonnet)
 JSON_FILES = $(patsubst $(JSONNET_DIR)/%.jsonnet,$(DASHBOARDS_DIR)/%.json,$(JSONNET_FILES))
-JB_EXE = ./bin/jb
-JSONNET_EXE = ./bin/jsonnet
+JB_EXE = $(shell pwd)/bin/jb
+JSONNET_EXE = $(shell pwd)/bin/jsonnet
 
 tools: $(JB_EXE) $(JSONNET_EXE) ## Install required local tools (jb, jsonnet).
 

--- a/grafana/dashboards/bench_dashboard.json
+++ b/grafana/dashboards/bench_dashboard.json
@@ -1,0 +1,236 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "description": "Compares bot PnL against a buy-and-hold benchmark.",
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "TimescaleDB",
+         "description": "Bot Total PnL vs. Normalized Benchmark Price (starts at 100).",
+         "fill": 1,
+         "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "SELECT bucket AS time, last_pnl FROM v_performance_vs_benchmark ORDER BY bucket",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Bot PnL",
+               "refId": "A"
+            },
+            {
+               "expr": "SELECT bucket AS time, normalized_price FROM v_performance_vs_benchmark ORDER BY bucket",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Benchmark (Normalized)",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "PnL vs. Benchmark (Normalized)",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "TimescaleDB",
+         "description": "Difference between PnL and normalized benchmark.",
+         "fill": 1,
+         "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 12
+         },
+         "id": 3,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "SELECT bucket AS time, alpha FROM v_performance_vs_benchmark ORDER BY bucket",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Alpha",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Performance Alpha",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      }
+   ],
+   "refresh": "",
+   "rows": [ ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "performance",
+      "benchmark"
+   ],
+   "templating": {
+      "list": [ ]
+   },
+   "time": {
+      "from": "now-6h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Performance vs. Benchmark",
+   "version": 0
+}

--- a/grafana/jsonnet/bench_dashboard.jsonnet
+++ b/grafana/jsonnet/bench_dashboard.jsonnet
@@ -1,7 +1,7 @@
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local row = grafana.row;
-local timeseries = grafana.timeseries;
+local graphPanel = grafana.graphPanel;
 local table = grafana.table;
 
 dashboard.new(
@@ -11,7 +11,7 @@ dashboard.new(
   timezone='browser',
 )
 .addPanel(
-  timeseries.new(
+  graphPanel.new(
     'PnL vs. Benchmark (Normalized)',
     datasource='TimescaleDB',
     description='Bot Total PnL vs. Normalized Benchmark Price (starts at 100).',
@@ -33,7 +33,7 @@ dashboard.new(
   gridPos={ x: 0, y: 0, w: 24, h: 12 }
 )
 .addPanel(
-  timeseries.new(
+  graphPanel.new(
     'Performance Alpha',
     datasource='TimescaleDB',
     description='Difference between PnL and normalized benchmark.',

--- a/grafana/jsonnet/jsonnetfile.json
+++ b/grafana/jsonnet/jsonnetfile.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "v0.1.0"
+    }
+  ]
+}

--- a/grafana/jsonnet/jsonnetfile.lock.json
+++ b/grafana/jsonnet/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "3336c69715f8f7a4d637582504c9fabd9d9ca081",
+      "sum": "w6zS28Rjs9EzRN/WoLLIdi028BvumxDTyLefYVoql2k="
+    }
+  ],
+  "legacyImports": false
+}


### PR DESCRIPTION
This commit fixes the `make grafana-render` command, which was failing due to a combination of issues:

- The `jb` executable was not found because the path was incorrect in the `Makefile`.
- The `jsonnetfile.json` was missing.
- The `grafonnet-lib` dependency was out of date, causing the `timeseries` field to be unavailable.
- I was crashing due to the creation of the `vendor` directory.

The following changes were made to address these issues:

- The `Makefile` was updated to use an absolute path for the `jb` and `jsonnet` executables.
- A `jsonnetfile.json` file was created with the correct dependencies.
- The `bench_dashboard.jsonnet` file was updated to use `graphPanel` instead of `timeseries`.
- The `.gitignore` file was updated to ignore the `vendor` directory.