### PR TITLE
Refactor: Improve usability of simulate mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ simulate: ## Run a backtest using trade data from a local CSV file.
 		echo "Usage: make simulate CSV_PATH=/path/to/your/trades.csv"; \
 		exit 1; \
 	fi
-	sudo -E docker compose run --build --rm bot-simulate --simulate --csv=$(CSV_PATH) --config=config/config.yaml
+	sudo -E docker compose run --rm --no-deps bot-simulate --simulate --csv=$(CSV_PATH) --config=config/config.yaml
 
 export-sim-data: ## Export order book data from the database to a CSV file for simulation.
 	@echo "Exporting simulation data..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,7 @@ services:
     container_name: obi-scalp-bot-simulate
     entrypoint: ["/usr/local/bin/obi-scalp-bot"]
     volumes:
-      - ./config:/app/config:ro
-      - ./pkg:/app/pkg:ro
-      - ./simulation:/app/simulation:ro
+      - .:/app
     networks:
       - bot_network
 


### PR DESCRIPTION
- Allow specifying CSV files from the project root in `make simulate`.
- Decouple `simulate` mode from the database, enabling faster, dependency-free simulations.