### PR TITLE
feat: Implement real-time PNL dashboard

### DIFF
--- a/db/migrations/001_create_trades_pnl_table.sql
+++ b/db/migrations/001_create_trades_pnl_table.sql
@@ -1,0 +1,15 @@
+-- 001_create_trades_pnl_table.sql
+
+CREATE TABLE trades_pnl (
+    trade_id BIGINT PRIMARY KEY,
+    pnl NUMERIC(20, 8) NOT NULL,
+    cumulative_pnl NUMERIC(20, 8) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (trade_id) REFERENCES trades(transaction_id)
+);
+
+-- Add cumulative columns to pnl_reports
+ALTER TABLE pnl_reports
+ADD COLUMN cumulative_total_pnl NUMERIC(20, 8) NOT NULL DEFAULT 0,
+ADD COLUMN cumulative_winning_trades INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN cumulative_losing_trades INTEGER NOT NULL DEFAULT 0;

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5
+	github.com/rodrigo-brito/hurst v1.0.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/testcontainers/testcontainers-go v0.38.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.38.0
@@ -63,7 +64,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/rodrigo-brito/hurst v1.0.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.5 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/grafana/dashboards/pnl_dashboard.json
+++ b/grafana/dashboards/pnl_dashboard.json
@@ -334,10 +334,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 12,
-        "x": 12,
-        "y": 0
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
       },
       "id": 4,
       "options": {
@@ -387,13 +387,13 @@
             "22": "n",
             "23": ")"
           },
-          "format": "table",
-          "rawSql": "SELECT total_pnl FROM pnl_reports ORDER BY time DESC LIMIT 1",
+          "format": "time_series",
+          "rawSql": "SELECT created_at AS time, cumulative_pnl FROM trades_pnl ORDER BY created_at",
           "refId": "A"
         }
       ],
-      "title": "合計損益",
-      "type": "stat"
+      "title": "累積損益",
+      "type": "timeseries"
     },
     {
       "datasource": "TimescaleDB",
@@ -466,7 +466,7 @@
             "23": ")"
           },
           "format": "table",
-          "rawSql": "SELECT winning_trades FROM pnl_reports ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT cumulative_winning_trades FROM pnl_reports ORDER BY time DESC LIMIT 1",
           "refId": "A"
         }
       ],
@@ -544,7 +544,7 @@
             "23": ")"
           },
           "format": "table",
-          "rawSql": "SELECT losing_trades FROM pnl_reports ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT cumulative_losing_trades FROM pnl_reports ORDER BY time DESC LIMIT 1",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
This commit introduces a new real-time PNL dashboard and the necessary backend changes to support it.

The key changes are:
- A new `trades_pnl` table to store the PNL for each individual trade.
- The `pnl_reports` table is now used to store cumulative PNL data.
- The `cmd/report/main.go` program has been updated to calculate PNL incrementally and populate the new tables.
- The Grafana dashboard has been updated to visualize the cumulative PNL over time, providing a more accurate and real-time view of profitability.