### PR TITLE
feat: Implement real-time PNL dashboard

### DIFF
--- a/db/schema/init-db.sh
+++ b/db/schema/init-db.sh
@@ -8,8 +8,14 @@ do
   sleep 1
 done
 
-# Apply all .sql files in the directory
-for f in /docker-entrypoint-initdb.d/*.sql; do
+# Apply schema files
+for f in /docker-entrypoint-initdb.d/schema/*.sql; do
   echo "Applying schema $f..."
+  psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB -f "$f"
+done
+
+# Apply migration files
+for f in /docker-entrypoint-initdb.d/migrations/*.sql; do
+  echo "Applying migration $f..."
   psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB -f "$f"
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,8 @@ services:
   db-init:
     image: postgres:14
     volumes:
-      - ./db/schema:/docker-entrypoint-initdb.d
+      - ./db/schema:/docker-entrypoint-initdb.d/schema
+      - ./db/migrations:/docker-entrypoint-initdb.d/migrations
     environment:
       POSTGRES_HOST: timescaledb
       POSTGRES_USER: ${DB_USER:-your_db_user}


### PR DESCRIPTION
This commit introduces a new real-time PNL dashboard and the necessary backend changes to support it.

The key changes are:
- A new `trades_pnl` table to store the PNL for each individual trade.
- The `pnl_reports` table is now used to store cumulative PNL data.
- The `cmd/report/main.go` program has been updated to calculate PNL incrementally and populate the new tables.
- The Grafana dashboard has been updated to visualize the cumulative PNL over time, providing a more accurate and real-time view of profitability.
- The `init-db` make command has been updated to run database migrations.