### PR TITLE
fix: Resolve database migration error on init-db

### DIFF
--- a/db/schema/init-db.sh
+++ b/db/schema/init-db.sh
@@ -8,14 +8,8 @@ do
   sleep 1
 done
 
-# Apply schema files
-for f in /docker-entrypoint-initdb.d/schema/*.sql; do
+# Apply all .sql files in the directory
+for f in /docker-entrypoint-initdb.d/*.sql; do
   echo "Applying schema $f..."
-  psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB -f "$f"
-done
-
-# Apply migration files
-for f in /docker-entrypoint-initdb.d/migrations/*.sql; do
-  echo "Applying migration $f..."
   psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB -f "$f"
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,26 +76,6 @@ services:
     networks:
       - bot_network
 
-  db-init:
-    image: postgres:14
-    volumes:
-      - ./db/schema:/docker-entrypoint-initdb.d/schema
-      - ./db/migrations:/docker-entrypoint-initdb.d/migrations
-    environment:
-      POSTGRES_HOST: timescaledb
-      POSTGRES_USER: ${DB_USER:-your_db_user}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-your_db_password}
-      POSTGRES_DB: ${DB_NAME:-obi_scalp_bot_db}
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - >
-        /docker-entrypoint-initdb.d/init-db.sh
-    networks:
-      - bot_network
-    depends_on:
-      timescaledb:
-        condition: service_healthy
-
   timescaledb:
     image: timescale/timescaledb-ha:pg14.9-ts2.11.2
     container_name: timescaledb-obi
@@ -107,6 +87,8 @@ services:
       POSTGRES_DB: ${DB_NAME:-obi_scalp_bot_db}
     volumes:
       - timescaledb_data:/var/lib/postgresql/data
+      - ./db/schema:/docker-entrypoint-initdb.d/01_schema
+      - ./db/migrations:/docker-entrypoint-initdb.d/02_migrations
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s


### PR DESCRIPTION
This commit fixes a persistent error that occurred when running `make init-db`. The `db-init` service was not correctly configured, leading to a "file not found" error for the `init-db.sh` script.

The following changes have been made to resolve this issue:

- The `db-init` service has been removed from `docker-compose.yml`.
- The `timescaledb` service in `docker-compose.yml` now mounts the `db/schema` and `db/migrations` directories directly into the container. This allows the official `postgres` entrypoint to automatically apply the schema and migrations in the correct order.
- The `Makefile` has been updated to remove the `init-db` command and introduce a new `migrate` command.
- The `up` command in the `Makefile` now calls the `migrate` command, ensuring that database migrations are run automatically after the services are started.

These changes simplify the database initialization process and resolve the error.