### PR TITLE
Fix: Pass DB credentials to migrate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ up: ## Start all services including the bot for live trading.
 
 migrate: ## Run database migrations
 	@echo "Running database migrations..."
-	sudo -E docker compose exec -T timescaledb sh -c "for f in /docker-entrypoint-initdb.d/02_migrations/*.sql; do psql -v ON_ERROR_STOP=1 --username \"$$POSTGRES_USER\" --dbname \"$$POSTGRES_DB\" -f \"$$f\"; done"
+	sudo -E docker compose exec -T -e POSTGRES_USER=$(DB_USER) -e POSTGRES_DB=$(DB_NAME) timescaledb sh -c 'for f in /docker-entrypoint-initdb.d/02_migrations/*.sql; do psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" -f "$$f"; done'
 
 monitor: ## Start monitoring services (DB, Grafana) without the bot.
 	@echo "Starting monitoring services (TimescaleDB, Grafana)..."


### PR DESCRIPTION
The `make migrate` command was failing because the `psql` command was attempting to connect as the `postgres` user, which does not exist. This was happening because the `POSTGRES_USER` and `POSTGRES_DB` environment variables were not being passed to the `docker compose exec` command.

This commit fixes the issue by explicitly passing the `DB_USER` and `DB_NAME` variables from the `.env` file to the `docker compose exec` command using the `-e` flag. This ensures that `psql` connects with the correct user and database during migrations.