### PR TITLE
Fix: Correct migrate command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ up: ## Start all services including the bot for live trading.
 
 migrate: ## Run database migrations
 	@echo "Running database migrations..."
-	sudo -E docker compose exec -T -e POSTGRES_USER=$(DB_USER) -e POSTGRES_DB=$(DB_NAME) timescaledb sh -c 'for f in /docker-entrypoint-initdb.d/02_migrations/*.sql; do psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" -f "$$f"; done'
+	sudo -E docker compose exec -T -e POSTG-RES_USER=$(DB_USER) -e POSTGRES_DB=$(DB_NAME) timescaledb sh -c 'if ls /docker-entrypoint-initdb.d/02_migrations/*.sql >/dev/null 2>&1; then for f in /docker-entrypoint-initdb.d/02_migrations/*.sql; do psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" -f "$$f"; done; else echo "No migration files found."; fi'
 
 monitor: ## Start monitoring services (DB, Grafana) without the bot.
 	@echo "Starting monitoring services (TimescaleDB, Grafana)..."


### PR DESCRIPTION
The previous migrate command would fail if there were no .sql files in the migrations directory. This change adds a check to ensure that the psql command is only run if there are .sql files present, preventing the error.