### PR TITLE
Refactor: Remove make replay feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: help up down logs shell clean test build replay monitor report
+.PHONY: help up down logs shell clean test build monitor report
 
 # ==============================================================================
 # HELP
@@ -56,10 +56,6 @@ shell: ## Access a shell inside the running bot container.
 clean: ## Stop, remove containers, and remove volumes.
 	@echo "Stopping application stack and removing volumes..."
 	sudo -E docker compose down -v --remove-orphans
-
-replay: ## Run a backtest using historical data from the database.
-	@echo "Running replay task..."
-	sudo -E docker compose run --build --rm bot-replay
 
 simulate: ## Run a backtest using trade data from a local CSV file.
 	@echo "Running simulation task..."

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -36,13 +36,6 @@ db_writer:
   # 非同期書き込みの有効化
   enable_async: false
 
-# リプレイモード設定
-replay:
-  # 開始時刻 (RFC3339形式)
-  start_time: "2025-07-13T00:00:00Z"
-  # 終了時刻 (RFC3339形式)
-  end_time: "2025-07-14T00:00:00Z"
-
 # PnLレポート設定
 pnl_report:
   # レポート生成間隔（分）

--- a/db/schema/001_tables.sql
+++ b/db/schema/001_tables.sql
@@ -32,7 +32,6 @@ SELECT add_compression_policy('order_book_updates', INTERVAL '7 days', if_not_ex
 -- 定期的なPnLのスナップショットや重要なイベント発生時のPnLを記録
 CREATE TABLE IF NOT EXISTS pnl_summary (
     time TIMESTAMPTZ NOT NULL,
-    replay_session_id TEXT,                      -- リプレイセッションID (リプレイ時のみ使用)
     strategy_id TEXT NOT NULL DEFAULT 'default', -- 戦略識別子
     pair TEXT NOT NULL,                          -- 通貨ペア
     realized_pnl DECIMAL NOT NULL DEFAULT 0.0,   -- 実現損益
@@ -49,7 +48,7 @@ SELECT create_hypertable('pnl_summary', 'time', if_not_exists => TRUE);
 -- 30日経過したチャンクを圧縮
 ALTER TABLE pnl_summary SET (
     timescaledb.compress,
-    timescaledb.compress_segmentby = 'replay_session_id, strategy_id, pair',
+    timescaledb.compress_segmentby = 'strategy_id, pair',
     timescaledb.compress_orderby = 'time DESC'
 );
 -- 圧縮ポリシーの追加 (例: 30日後に圧縮ジョブを実行)
@@ -59,14 +58,12 @@ SELECT add_compression_policy('pnl_summary', INTERVAL '30 days', if_not_exists =
 CREATE INDEX IF NOT EXISTS idx_order_book_updates_pair_time ON order_book_updates (pair, time DESC);
 CREATE INDEX IF NOT EXISTS idx_order_book_updates_side_time ON order_book_updates (side, time DESC);
 
-CREATE INDEX IF NOT EXISTS idx_pnl_summary_replay_id_time ON pnl_summary (replay_session_id, time DESC);
 CREATE INDEX IF NOT EXISTS idx_pnl_summary_strategy_pair_time ON pnl_summary (strategy_id, pair, time DESC);
 
 -- Botが受信した約定履歴テーブル (trades)
 -- WebSocketから受信した全ての約定情報を記録
 CREATE TABLE IF NOT EXISTS trades (
     time TIMESTAMPTZ NOT NULL,
-    replay_session_id TEXT, -- リプレイセッションID (リプレイ時のみ使用)
     pair TEXT NOT NULL,
     side TEXT NOT NULL,        -- 'buy' or 'sell'
     price DECIMAL NOT NULL,
@@ -83,14 +80,13 @@ SELECT create_hypertable('trades', 'time', if_not_exists => TRUE);
 -- 7日経過したチャンクを圧縮
 ALTER TABLE trades SET (
     timescaledb.compress,
-    timescaledb.compress_segmentby = 'replay_session_id, pair, side',
+    timescaledb.compress_segmentby = 'pair, side',
     timescaledb.compress_orderby = 'time DESC, transaction_id DESC'
 );
 
 -- 圧縮ポリシーの追加 (例: 7日後に圧縮ジョブを実行)
 SELECT add_compression_policy('trades', INTERVAL '7 days', if_not_exists => TRUE);
 
-CREATE INDEX IF NOT EXISTS idx_trades_replay_id_time ON trades (replay_session_id, time DESC);
 CREATE INDEX IF NOT EXISTS idx_trades_pair_time ON trades (pair, time DESC);
 -- CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_transaction_id ON trades (transaction_id, time);
 
@@ -98,7 +94,6 @@ CREATE INDEX IF NOT EXISTS idx_trades_pair_time ON trades (pair, time DESC);
 -- report-generatorによって生成された分析レポートの結果を格納
 CREATE TABLE IF NOT EXISTS pnl_reports (
     time TIMESTAMPTZ NOT NULL,
-    replay_session_id TEXT,                      -- リプレイセッションID (リプレイ時のみ使用)
     start_date TIMESTAMPTZ NOT NULL,
     end_date TIMESTAMPTZ NOT NULL,
     total_trades INT NOT NULL,
@@ -135,10 +130,6 @@ CREATE TABLE IF NOT EXISTS pnl_reports (
 
 -- pnl_reports テーブルをHypertableに変換
 SELECT create_hypertable('pnl_reports', 'time', if_not_exists => TRUE);
-
--- インデックスの追加
-CREATE INDEX IF NOT EXISTS idx_pnl_reports_replay_id_time ON pnl_reports (replay_session_id, time DESC);
-
 
 -- （オプション）ポジション管理テーブル (positions)
 -- 通貨ペアごとの現在の詳細なポジション情報を保持 (PnLサマリーと重複する部分もあるがより詳細)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,27 +44,6 @@ services:
     networks:
       - bot_network
 
-  bot-replay:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: obi-scalp-bot-replay
-    entrypoint: ["/usr/local/bin/obi-scalp-bot"]
-    volumes:
-      - ./.env:/app/.env:ro
-      - ./config:/app/config:ro
-      - ./pkg:/app/pkg:ro
-    command: ["-replay", "-config", "/app/config/app_config.yaml"]
-    env_file:
-      - .env
-    environment:
-      - DB_HOST=timescaledb
-    depends_on:
-      timescaledb:
-        condition: service_healthy
-    networks:
-      - bot_network
-
   bot-simulate:
     build:
       context: .

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/pashagolub/pgxmock/v3 v3.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v4 v4.25.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/pashagolub/pgxmock/v3 v3.4.0 h1:87VMr2q7m2+6VzXo4Tsp9kMklGlj6mMN19Hp/bp2Rwo=
-github.com/pashagolub/pgxmock/v3 v3.4.0/go.mod h1:FvCl7xqPbLLI3XohihJ1NzXnikjM3q/NWSixg4t9hrU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/datastore/csv_reader.go
+++ b/internal/datastore/csv_reader.go
@@ -13,13 +13,13 @@ import (
 	"github.com/your-org/obi-scalp-bot/pkg/logger"
 )
 
-// StreamMarketEventsFromCSV reads order book data from a CSV file and streams it as MarketEvent
+// StreamMarketEventsFromCSV reads order book data from a CSV file and streams it as coincheck.OrderBookData
 // instances through a channel. It groups updates by timestamp to form snapshots.
 // The function returns a channel for events and a channel for errors.
 // The CSV file is expected to have a header and the following columns:
 // time, pair, side, price, size, is_snapshot
-func StreamMarketEventsFromCSV(ctx context.Context, filePath string) (<-chan MarketEvent, <-chan error) {
-	eventCh := make(chan MarketEvent)
+func StreamMarketEventsFromCSV(ctx context.Context, filePath string) (<-chan coincheck.OrderBookData, <-chan error) {
+	eventCh := make(chan coincheck.OrderBookData)
 	errCh := make(chan error, 1)
 
 	go func() {
@@ -62,13 +62,11 @@ func StreamMarketEventsFromCSV(ctx context.Context, filePath string) (<-chan Mar
 			}
 
 			select {
-			case eventCh <- OrderBookEvent{
-				OrderBook: coincheck.OrderBookData{
-					PairStr: currentPair,
-					Bids:    bids,
-					Asks:    asks,
-				},
-				Time: currentTime,
+			case eventCh <- coincheck.OrderBookData{
+				PairStr: currentPair,
+				Bids:    bids,
+				Asks:    asks,
+				Time:    currentTime,
 			}:
 				totalSnapshots++
 			case <-ctx.Done():

--- a/internal/datastore/repository.go
+++ b/internal/datastore/repository.go
@@ -3,34 +3,11 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
-	"github.com/your-org/obi-scalp-bot/internal/exchange/coincheck"
 )
-
-// MarketEvent is an interface for market events (trades, order book updates).
-type MarketEvent interface {
-	GetTime() time.Time
-}
-
-// TradeEvent represents a single trade event from the database.
-type TradeEvent struct {
-	Trade coincheck.TradeData
-	Time  time.Time
-}
-
-func (e TradeEvent) GetTime() time.Time { return e.Time }
-
-// OrderBookEvent represents an order book snapshot/update from the database.
-type OrderBookEvent struct {
-	OrderBook coincheck.OrderBookData
-	Time      time.Time
-}
-
-func (e OrderBookEvent) GetTime() time.Time { return e.Time }
 
 // Repository handles database operations for fetching backtest data.
 type Repository struct {
@@ -42,39 +19,9 @@ func NewRepository(db *pgxpool.Pool) *Repository {
 	return &Repository{db: db}
 }
 
-// FetchMarketEvents fetches trades and order book updates from the database
-// within the given time range and returns them as a sorted slice of MarketEvent.
-func (r *Repository) FetchMarketEvents(ctx context.Context, pair string, startTime, endTime time.Time) ([]MarketEvent, error) {
-	trades, err := r.fetchTrades(ctx, pair, startTime, endTime)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch trades: %w", err)
-	}
-
-	orderBooks, err := r.fetchOrderBookUpdates(ctx, pair, startTime, endTime)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch order book updates: %w", err)
-	}
-
-	// Combine and sort events
-	events := make([]MarketEvent, 0, len(trades)+len(orderBooks))
-	for _, t := range trades {
-		events = append(events, t)
-	}
-	for _, ob := range orderBooks {
-		events = append(events, ob)
-	}
-
-	sort.Slice(events, func(i, j int) bool {
-		return events[i].GetTime().Before(events[j].GetTime())
-	})
-
-	return events, nil
-}
-
 // Trade はデータベースからの取引を表します。
 type Trade struct {
 	Time            time.Time       `json:"time"`
-	ReplaySessionID *string         `json:"replay_session_id"`
 	Pair            string          `json:"pair"`
 	Side            string          `json:"side"`
 	Price           decimal.Decimal `json:"price"`
@@ -85,7 +32,6 @@ type Trade struct {
 
 // Report は損益分析の結果を保持します。
 type Report struct {
-	ReplaySessionID    *string         `json:"replay_session_id"`
 	StartDate          time.Time       `json:"start_date"`
 	EndDate            time.Time       `json:"end_date"`
 	TotalTrades        int             `json:"total_trades"`        // Executed trades
@@ -109,7 +55,7 @@ type Report struct {
 // FetchAllTradesForReport はデータベースからすべてのトレードを取得します。
 func (r *Repository) FetchAllTradesForReport(ctx context.Context) ([]Trade, error) {
 	query := `
-        SELECT time, replay_session_id, pair, side, price, size, transaction_id, is_cancelled
+        SELECT time, pair, side, price, size, transaction_id, is_cancelled
         FROM trades
         ORDER BY time ASC;
     `
@@ -122,7 +68,7 @@ func (r *Repository) FetchAllTradesForReport(ctx context.Context) ([]Trade, erro
 	var trades []Trade
 	for rows.Next() {
 		var t Trade
-		if err := rows.Scan(&t.Time, &t.ReplaySessionID, &t.Pair, &t.Side, &t.Price, &t.Size, &t.TransactionID, &t.IsCancelled); err != nil {
+		if err := rows.Scan(&t.Time, &t.Pair, &t.Side, &t.Price, &t.Size, &t.TransactionID, &t.IsCancelled); err != nil {
 			return nil, err
 		}
 		trades = append(trades, t)
@@ -138,7 +84,6 @@ func AnalyzeTrades(trades []Trade) (Report, error) {
 	}
 
 	var executedTrades []Trade
-	var replaySessionID *string
 	cancelledCount := 0
 	for _, t := range trades {
 		if t.IsCancelled {
@@ -146,14 +91,10 @@ func AnalyzeTrades(trades []Trade) (Report, error) {
 		} else {
 			executedTrades = append(executedTrades, t)
 		}
-		if t.ReplaySessionID != nil {
-			replaySessionID = t.ReplaySessionID
-		}
 	}
 
 	if len(executedTrades) == 0 {
 		return Report{
-			ReplaySessionID: replaySessionID,
 			StartDate:       trades[0].Time,
 			EndDate:         trades[len(trades)-1].Time,
 			CancelledTrades: cancelledCount,
@@ -262,7 +203,6 @@ func AnalyzeTrades(trades []Trade) (Report, error) {
 	}
 
 	return Report{
-		ReplaySessionID:    replaySessionID,
 		StartDate:          startDate,
 		EndDate:            endDate,
 		TotalTrades:        totalExecutedTrades,
@@ -288,17 +228,17 @@ func AnalyzeTrades(trades []Trade) (Report, error) {
 func (r *Repository) SavePnlReport(ctx context.Context, report Report) error {
 	query := `
         INSERT INTO pnl_reports (
-            time, replay_session_id, start_date, end_date, total_trades, cancelled_trades,
+            time, start_date, end_date, total_trades, cancelled_trades,
             cancellation_rate, winning_trades, losing_trades, win_rate,
             long_winning_trades, long_losing_trades, long_win_rate,
             short_winning_trades, short_losing_trades, short_win_rate,
             total_pnl, average_profit, average_loss, risk_reward_ratio
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
         );
     `
 	_, err := r.db.Exec(ctx, query,
-		time.Now(), report.ReplaySessionID, report.StartDate, report.EndDate, report.TotalTrades, report.CancelledTrades,
+		time.Now(), report.StartDate, report.EndDate, report.TotalTrades, report.CancelledTrades,
 		report.CancellationRate, report.WinningTrades, report.LosingTrades, report.WinRate,
 		report.LongWinningTrades, report.LongLosingTrades, report.LongWinRate,
 		report.ShortWinningTrades, report.ShortLosingTrades, report.ShortWinRate,
@@ -319,103 +259,4 @@ func (r *Repository) DeleteOldPnlReports(ctx context.Context, maxAgeHours int) (
 		return 0, err
 	}
 	return result.RowsAffected(), nil
-}
-
-func (r *Repository) fetchTrades(ctx context.Context, pair string, startTime, endTime time.Time) ([]TradeEvent, error) {
-	query := `
-        SELECT transaction_id, pair, price, size, side, time
-        FROM trades
-        WHERE pair = $1 AND time >= $2 AND time < $3
-        ORDER BY time ASC;
-    `
-	rows, err := r.db.Query(ctx, query, pair, startTime, endTime)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var trades []TradeEvent
-	for rows.Next() {
-		var t struct {
-			TransactionID int64
-			Pair          string
-			Price         float64
-			Size          float64
-			Side          string
-			Time          time.Time
-		}
-		if err := rows.Scan(&t.TransactionID, &t.Pair, &t.Price, &t.Size, &t.Side, &t.Time); err != nil {
-			return nil, err
-		}
-		trades = append(trades, TradeEvent{
-			Trade: coincheck.TradeData{
-				ID:        fmt.Sprintf("%d", t.TransactionID),
-				PairStr:   t.Pair,
-				RateStr:   fmt.Sprintf("%f", t.Price),
-				AmountStr: fmt.Sprintf("%f", t.Size),
-				SideStr:   t.Side,
-			},
-			Time: t.Time,
-		})
-	}
-	return trades, rows.Err()
-}
-
-func (r *Repository) fetchOrderBookUpdates(ctx context.Context, pair string, startTime, endTime time.Time) ([]OrderBookEvent, error) {
-	// This is a simplified implementation. A real implementation would need to
-	// reconstruct the order book state at each point in time.
-	// For now, we fetch snapshots and treat them as individual events.
-	query := `
-        SELECT time, side, price, size
-        FROM order_book_updates
-        WHERE pair = $1 AND time >= $2 AND time < $3
-        ORDER BY time ASC;
-    `
-	// This query is likely insufficient for a proper backtest.
-	// A full backtest would require reconstructing the book from a snapshot and subsequent diffs.
-	// For this iteration, we are assuming simplified logic where each "update" can be treated as a state.
-	rows, err := r.db.Query(ctx, query, pair, startTime, endTime)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	// Group updates by timestamp
-	updatesByTime := make(map[time.Time][][]string)
-	for rows.Next() {
-		var t time.Time
-		var side string
-		var price, size float64
-		if err := rows.Scan(&t, &side, &price, &size); err != nil {
-			return nil, err
-		}
-		rateStr := fmt.Sprintf("%f", price)
-		amountStr := fmt.Sprintf("%f", size)
-		updatesByTime[t] = append(updatesByTime[t], []string{rateStr, amountStr, side})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	var events []OrderBookEvent
-	for t, updates := range updatesByTime {
-		var bids, asks [][]string
-		for _, u := range updates {
-			if u[2] == "bid" {
-				bids = append(bids, u[:2])
-			} else {
-				asks = append(asks, u[:2])
-			}
-		}
-		events = append(events, OrderBookEvent{
-			OrderBook: coincheck.OrderBookData{
-				PairStr: pair,
-				Bids:    bids,
-				Asks:    asks,
-			},
-			Time: t,
-		})
-	}
-
-	return events, nil
 }

--- a/internal/exchange/coincheck/types.go
+++ b/internal/exchange/coincheck/types.go
@@ -1,7 +1,10 @@
 // Package coincheck handles interactions with the Coincheck exchange.
 package coincheck
 
-import "strconv"
+import (
+	"strconv"
+	"time"
+)
 
 // BookLevel represents a single price level in the order book.
 // Rate and Amount are strings as received from the WebSocket API.
@@ -33,6 +36,7 @@ type OrderBookData struct {
 	Bids         [][]string `json:"bids"`
 	Asks         [][]string `json:"asks"`
 	LastUpdateAt string     `json:"last_update_at"`
+	Time         time.Time
 }
 
 // OrderBookUpdate represents an update to the order book received via WebSocket.

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -115,15 +115,6 @@ func (l *defaultLogger) Fatalf(format string, args ...interface{}) {
 	os.Exit(1)
 }
 
-// SetReplayMode configures the global logger to include a replay session ID prefix.
-func SetReplayMode(sessionID string) {
-	if globalStd, ok := std.(*defaultLogger); ok {
-		globalStd.prefix = fmt.Sprintf("[REPLAY-%s] ", sessionID)
-	} else {
-		log.Println("Error: Global logger is not of type *defaultLogger, cannot set replay mode prefix.")
-	}
-}
-
 var (
 	std      Logger
 	logMutex sync.Mutex


### PR DESCRIPTION
This commit removes the `make replay` feature and all related code, including:
- `replay` target in Makefile
- `bot-replay` service in docker-compose.yml
- `replay` section in config/app_config.yaml
- `replay_session_id` from database schema and related code
- `replay` flag and logic from `cmd/bot/main.go`
- Refactored `ReplayExecutionEngine` to remove dbWriter dependency
- Refactored `datastore` to remove replay-specific types and functions