### PR TITLE
Fix: `make up` 実行時の警告を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 # ==============================================================================
 up: ## Start all services including the bot for live trading.
 	@echo "Starting all services (including trading bot)..."
-	sudo -E docker compose up -d --build
+	sudo -E docker compose -f docker-compose.yml up -d --build bot timescaledb grafana adminer
 	$(MAKE) migrate
 
 migrate: ## Run database migrations


### PR DESCRIPTION
`make up` 実行時に `docker-compose.override.yml` が読み込まれ、 `optimizer` サービスで定義されている環境変数が未設定であるため
警告が表示されていました。

`up` ターゲットでは `docker-compose.override.yml` は不要なため、 `-f docker-compose.yml` オプションを追加して明示的に
`docker-compose.yml` のみを読み込むように修正しました。

また、これにより `bot-simulate` サービスが起動しようとして
エラーが発生する問題が起きたため、`up` ターゲットで起動する
サービスを明示的に指定するように修正しました。