### PR TITLE
Alright, I'll configure `timescaledb` to listen on all addresses.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
   timescaledb:
     image: timescale/timescaledb-ha:pg14.9-ts2.11.2
     container_name: timescaledb-obi
+    command: postgres -c listen_addresses='*'
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
First, I'll use the `command` option in `docker-compose.yml` to set `listen_addresses='*'` for the `timescaledb` service. Then, I'll update `db/init-db.sh` to allow connections from any host.