### PR TITLE
Fix: DBマイグレーションのエラーを修正

### DIFF
--- a/db/migrations/001_create_trades_pnl_table.sql
+++ b/db/migrations/001_create_trades_pnl_table.sql
@@ -10,6 +10,6 @@ CREATE TABLE trades_pnl (
 
 -- Add cumulative columns to pnl_reports
 ALTER TABLE pnl_reports
-ADD COLUMN cumulative_total_pnl NUMERIC(20, 8) NOT NULL DEFAULT 0,
-ADD COLUMN cumulative_winning_trades INTEGER NOT NULL DEFAULT 0,
-ADD COLUMN cumulative_losing_trades INTEGER NOT NULL DEFAULT 0;
+ADD COLUMN IF NOT EXISTS cumulative_total_pnl NUMERIC(20, 8) NOT NULL DEFAULT 0,
+ADD COLUMN IF NOT EXISTS cumulative_winning_trades INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN IF NOT EXISTS cumulative_losing_trades INTEGER NOT NULL DEFAULT 0;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,10 @@ services:
       - bot_network
 
   bot-simulate:
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    image: obi-scalp-bot-image:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # image: obi-scalp-bot-image:latest
     container_name: obi-scalp-bot-simulate
     entrypoint: ["/usr/local/bin/obi-scalp-bot"]
     volumes:


### PR DESCRIPTION
- `db/migrations` の `ALTER TABLE` に `IF NOT EXISTS` を追加し、冪等性を確保
- `docker-compose.yml` の `bot-simulate` がビルドされるように修正
- `.env` ファイルが見つからないエラーを修正するため、`.env.sample`をコピーする手順を追加（ただし、実際のファイルは追加しない）

これにより、`make up` 実行時の `relation does not exist` エラーやビルドエラーが解消されることを目指します。