### PR TITLE
I've corrected the risk check logic to consider the prospective posit…

### DIFF
--- a/internal/engine/execution_engine_test.go
+++ b/internal/engine/execution_engine_test.go
@@ -749,7 +749,7 @@ func TestExecutionEngine_RiskManagement(t *testing.T) {
 		_, err := execEngine.PlaceOrder(context.Background(), "btc_jpy", "buy", 5000000, 0.01, false)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "risk check failed: current position value")
+		assert.Contains(t, err.Error(), "risk check failed: prospective position value")
 		assert.EqualValues(t, 0, atomic.LoadInt32(&newOrderRequestCount), "NewOrder should not have been called")
 	})
 


### PR DESCRIPTION
…ion.

Previously, the risk check logic in the execution engine was only considering the current position value, not the value after the new order would be executed. This could lead to positions exceeding the maximum allowed size.

I've corrected the logic to calculate the prospective position value, including the new order, and check that against the `max_position_jpy` limit. I've also updated the relevant test to reflect this change in logic and error messaging.