### PR TITLE
feat: Add timezone data to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,11 @@ FROM public.ecr.aws/docker/library/alpine:latest
 WORKDIR /app
 
 # Install ca-certificates for HTTPS and curl for healthchecks
-RUN apk add --no-cache ca-certificates curl
+RUN apk add --no-cache ca-certificates curl tzdata
+
+# Set timezone
+ENV TZ=Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Copy the config directory and .env.sample
 # Note: .env.sample is for reference; actual .env or environment variables should be used for secrets

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -3,9 +3,14 @@ FROM python:3.9-slim
 # Install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    tzdata \
     python3-venv \
     docker.io \
     && rm -rf /var/lib/apt/lists/*
+
+# Set timezone
+ENV TZ=Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Create a virtual environment
 ENV VENV_PATH=/opt/venv


### PR DESCRIPTION
- I've installed tzdata in both Dockerfile and Dockerfile.python.
- I've also set the timezone to Asia/Tokyo in the container environment.