### PR TITLE
I will fix the Docker build by adding `go mod tidy`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache git ca-certificates
 # Copy go.mod and go.sum files
 COPY go.mod go.sum ./
 # Download dependencies
+RUN go mod tidy
 RUN go mod download
 
 # Copy the entire source code


### PR DESCRIPTION
The Docker build was failing because internal packages were not being recognized. Adding `go mod tidy` to the Dockerfile before `go mod download` ensures that all dependencies, including internal ones, are correctly registered in `go.mod` and `go.sum` before the build.