### PR TITLE
perf: シミュレーションの最適化とログレベルの調整

### DIFF
--- a/internal/engine/execution_engine.go
+++ b/internal/engine/execution_engine.go
@@ -526,17 +526,17 @@ func (e *ReplayExecutionEngine) PlaceOrder(ctx context.Context, pair string, ord
 		if rate >= bestAsk && bestAsk > 0 {
 			executed = true
 			executedPrice = bestAsk
-			logger.Infof("[%s] Buy order matched: Rate %.2f >= BestAsk %.2f. Executing at %.2f", mode, rate, bestAsk, executedPrice)
+			logger.Debugf("[%s] Buy order matched: Rate %.2f >= BestAsk %.2f. Executing at %.2f", mode, rate, bestAsk, executedPrice)
 		} else {
-			logger.Infof("[%s] Buy order NOT matched: Rate %.2f < BestAsk %.2f. Order would be on book.", mode, rate, bestAsk)
+			logger.Debugf("[%s] Buy order NOT matched: Rate %.2f < BestAsk %.2f. Order would be on book.", mode, rate, bestAsk)
 		}
 	} else if orderType == "sell" {
 		if rate <= bestBid && bestBid > 0 {
 			executed = true
 			executedPrice = bestBid
-			logger.Infof("[%s] Sell order matched: Rate %.2f <= BestBid %.2f. Executing at %.2f", mode, rate, bestBid, executedPrice)
+			logger.Debugf("[%s] Sell order matched: Rate %.2f <= BestBid %.2f. Executing at %.2f", mode, rate, bestBid, executedPrice)
 		} else {
-			logger.Infof("[%s] Sell order NOT matched: Rate %.2f > BestBid %.2f. Order would be on book.", mode, rate, bestBid)
+			logger.Debugf("[%s] Sell order NOT matched: Rate %.2f > BestBid %.2f. Order would be on book.", mode, rate, bestBid)
 		}
 	}
 
@@ -586,7 +586,7 @@ func (e *ReplayExecutionEngine) PlaceOrder(ctx context.Context, pair string, ord
 	}
 	trade.RealizedPnL = realizedPnL
 	e.ExecutedTrades = append(e.ExecutedTrades, trade) // Append after PnL calculation
-	logger.Infof("[%s] Position updated: %s", mode, e.position.String())
+	logger.Debugf("[%s] Position updated: %s", mode, e.position.String())
 
 	// Calculate PnL
 	positionSize, avgEntryPrice := e.position.Get()
@@ -594,7 +594,7 @@ func (e *ReplayExecutionEngine) PlaceOrder(ctx context.Context, pair string, ord
 	totalRealizedPnL := e.pnlCalculator.GetRealizedPnL()
 	totalPnL := totalRealizedPnL + unrealizedPnL
 
-	logger.Infof("[%s] PnL Update: Realized=%.2f, Unrealized=%.2f, Total=%.2f", mode, realizedPnL, unrealizedPnL, totalPnL)
+	logger.Debugf("[%s] PnL Update: Realized=%.2f, Unrealized=%.2f, Total=%.2f", mode, realizedPnL, unrealizedPnL, totalPnL)
 
 	return &coincheck.OrderResponse{
 		Success: true,
@@ -607,7 +607,7 @@ func (e *ReplayExecutionEngine) PlaceOrder(ctx context.Context, pair string, ord
 
 // CancelOrder simulates cancelling an order.
 func (e *ReplayExecutionEngine) CancelOrder(ctx context.Context, orderID int64) (*coincheck.CancelResponse, error) {
-	logger.Infof("[Simulation] Simulating cancellation of order ID: %d", orderID)
+	logger.Debugf("[Simulation] Simulating cancellation of order ID: %d", orderID)
 	return &coincheck.CancelResponse{
 		Success: true,
 		ID:      orderID,


### PR DESCRIPTION
`make simulate` の実行時間を短縮するため、以下の最適化を実施しました。

- `internal/datastore/csv_reader.go`:
  - `time.Parse` の呼び出しを、特定のフォーマットに決め打ちすることで高速化。
  - `fmt.Sprintf` をより高速な `strconv.FormatFloat` に置き換え。
  - `append` による再確保を減らすため、スライスを事前に確保。

- `internal/signal/signal.go`:
  - 負荷の高いハースト指数の計算を1分に1回に間引くことで、CPUとメモリの使用量を大幅に削減。

また、シミュレーション実行時のログが大量に出力される問題を解消するため、`[Simulation]` を含むログを `INFO` レベルから `DEBUG` レベルに変更しました。