### PR TITLE
fix: Makefileのreportターゲットのコマンドを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,10 @@ report: ## Generate and display a PnL report from recent data.
 		exit 1; \
 	fi; \
 	echo "Running simulation on $$SIM_CSV_PATH..."; \
-	@SIM_OUTPUT=$$(make simulate CSV_PATH=$$SIM_CSV_PATH); \
-	sudo -E docker compose exec -T report-generator sh -c "echo '$${SIM_OUTPUT}' | /app/build/report"
-	@rm "$$SIM_CSV_PATH"; \
-	echo "Cleaned up simulation data."
+	@SIM_OUTPUT=$$(make simulate CSV_PATH=$$SIM_CSV_PATH);
+	@echo "$${SIM_OUTPUT}" | sudo -E docker compose exec -T report-generator /app/build/report
+	@rm "$$SIM_CSV_PATH";
+	@echo "Cleaned up simulation data."
 
 optimize: build ## Run hyperparameter optimization using Optuna. Accepts HOURS_BEFORE or CSV_PATH.
 	@echo "Running hyperparameter optimization..."

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ report: ## Generate and display a PnL report from recent data.
 	fi; \
 	echo "Running simulation on $$SIM_CSV_PATH..."; \
 	@SIM_OUTPUT=$$(make simulate CSV_PATH=$$SIM_CSV_PATH);
-	@echo "$${SIM_OUTPUT}" | sudo -E docker compose exec -T report-generator /app/build/report
+	@echo "$${SIM_OUTPUT}" | sudo -E docker compose exec -T report-generator build/report
 	@rm "$$SIM_CSV_PATH";
 	@echo "Cleaned up simulation data."
 


### PR DESCRIPTION
`make report`実行時に発生していた `not found` エラーを修正しました。
`@SIM_OUTPUT`の行を一行にまとめ、パイプ処理が正しく行われるようにしました。