### PR TITLE
fix: `make report`の実行エラーを修正しました。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,8 @@ report: ## Generate and display a PnL report from the latest simulation CSV.
 		exit 1; \
 	fi; \
 	echo "Running simulation on $$SIM_CSV_PATH..."; \
-	@make simulate CSV_PATH=$$SIM_CSV_PATH | sudo -E docker compose exec -T report-generator build/report
+	sudo -E docker compose up -d report-generator; \
+	make simulate CSV_PATH=$$SIM_CSV_PATH | sudo -E docker compose exec -T report-generator build/report
 
 optimize: build ## Run hyperparameter optimization using Optuna. Accepts HOURS_BEFORE or CSV_PATH.
 	@echo "Running hyperparameter optimization..."


### PR DESCRIPTION
`make report`実行時に発生していた`@make: not found`エラーと`service "report-generator" is not running`エラーを修正しました。

- `@make`を`make`に修正
- `report-generator`サービスを起動するコマンドを追加