### PR TITLE
fix: report-generatorの起動待ちを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ report: ## Generate and display a PnL report from the latest simulation CSV.
 	fi; \
 	echo "Running simulation on $$SIM_CSV_PATH..."; \
 	sudo -E docker compose up -d report-generator; \
+	sleep 5; \
 	SIM_OUTPUT=$$(make simulate CSV_PATH=$$SIM_CSV_PATH); \
 	echo "$${SIM_OUTPUT}" | sudo -E docker compose exec -T report-generator build/report
 


### PR DESCRIPTION
`make report`実行時に発生していた`service "report-generator" is not running`エラーを修正するため、`docker compose up`の後に`sleep 5`を追加し、サービスの起動を待つようにしました。