### PR TITLE
fix: report-generatorがすぐに終了する問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
     working_dir: /app
     networks:
       - bot_network
+    command: ["sleep", "infinity"]
     healthcheck:
       test: ["CMD-SHELL", "test -f /app/build/report"]
       interval: 1s


### PR DESCRIPTION
`report-generator`サービスに`command: ["sleep", "infinity"]`を追加し、コンテナが起動し続けるようにしました。 これにより、`service "report-generator" is not running`エラーが解消されるはずです。