### PR TITLE
fix: report-generatorに環境変数を渡すように修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,8 @@ services:
     volumes:
       - .:/app
     working_dir: /app
+    env_file:
+      - .env
     networks:
       - bot_network
     command: ["sleep", "infinity"]


### PR DESCRIPTION
`docker-compose.yml`の`report-generator`サービスに`env_file`を追加し、`.env`ファイルから環境変数を読み込むようにしました。 これにより、`Database environment variables are not set.`エラーが解消されるはずです。