### PR TITLE
feat(optimizer): 自律的なパラメータ最適化フローを導入

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,10 @@ services:
     networks:
       - bot_network
     depends_on:
-      - timescaledb
+      bot:
+        condition: service_started
+      timescaledb:
+        condition: service_healthy
     command: python optimizer/optimizer.py
     healthcheck:
       test: ["CMD-SHELL", "test -f /data/params/trade_config.yaml"]

--- a/optimizer/Dockerfile
+++ b/optimizer/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.9-slim
 # Install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    make \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a virtual environment

--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -319,8 +319,5 @@ def save_optimization_history(history_data):
 
 
 if __name__ == "__main__":
-    # Build the Go binary first
-    logging.info("Ensuring Go binary is built...")
-    # Run make from the root directory
-    subprocess.run(['make', 'build'], check=True, cwd=APP_ROOT)
+    # The Go binary is expected to be built by the Docker build process of the 'bot' service.
     main()


### PR DESCRIPTION
市場の変化に適応するため、パラメータの自律的な最適化フローを導入しました。
`drift-monitor` と `optimizer` の2つの新しいサービスがこの機能を実現します。

主な変更点:
- **Drift Monitor**: リアルタイムの取引パフォーマンス（Sharpeレシオ、PF等）を監視し、定時実行、性能ドリフト、市場急変動をトリガーとして最適化を開始します。
- **Optimizer**: トリガーに応じて動的に学習/検証期間を設定し、Optunaによるパラメータ探索を実行します。Out-of-Sample検証での合格基準を満たした場合のみ、新しいパラメータを本番botに適用します。
- **動的リロード**: 本番botは、取引を中断することなく新しいパラメータを自動的にリロードします。
- **ディレクトリ構成**: `optimizer`と`drift_monitor`のロジックをルート直下の `optimizer/` ディレクトリに格納しました。
- **可視化**: 最適化の実行履歴、トリガー種別、OOS検証結果などを確認できるGrafanaダッシュボードを追加しました。
- **設定更新**: `docker-compose.yml` と `Makefile` を更新し、新サービスを統合しました。
- **修正**: Docker in Docker問題を解決するため、`optimizer`コンテナ内でのビルドを不要にし、`depends_on`でサービスの起動順序を制御するようにしました。
- **修正**: `bot`サービスが起動時に設定ファイルを見つけられるよう、`optimizer`が起動時にデフォルトの設定ファイルを生成する機能を追加しました。
- **修正**: `docker-compose.yml`に`healthcheck`と`depends_on`を追加し、`bot`と`optimizer`の起動順序を制御することで、起動時エラーを解決しました。