### PR TITLE
Fix: Remove docker dependency from optimizer

### DIFF
--- a/optimizer/Dockerfile
+++ b/optimizer/Dockerfile
@@ -1,11 +1,9 @@
 FROM python:3.9-slim
 
-# Install dependencies
+# Install Go
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    make \
-    docker.io \
-    docker-compose-plugin \
+    golang \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a virtual environment
@@ -17,3 +15,6 @@ ENV PATH="$VENV_PATH/bin:$PATH"
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the entire source code
+COPY . .

--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -58,15 +58,11 @@ def export_data(hours_before, is_oos_split=False, oos_hours=0):
     db_host = os.getenv('DB_HOST')
 
     cmd = [
-        'docker', 'compose', 'run', '--rm',
-        '-v', f'{os.getcwd()}/simulation:/app/simulation',
-        '-e', f'DB_USER={db_user}',
-        '-e', f'DB_PASSWORD={db_password}',
-        '-e', f'DB_NAME={db_name}',
-        '-e', f'DB_HOST={db_host}',
-        'builder',
-        'sh', '-c',
-        f'cd /app && go run cmd/export/main.go --hours-before={hours_before} --no-zip'
+        'go',
+        'run',
+        'cmd/export/main.go',
+        f'--hours-before={hours_before}',
+        '--no-zip'
     ]
 
 


### PR DESCRIPTION
The optimizer was previously calling `docker compose run` to execute the `export_data` command. This created a dependency on the docker daemon from within the optimizer container.

This change modifies the `export_data` function to call `go run` directly, and updates the `optimizer/Dockerfile` to include the Go toolchain and the application source code.