### PR TITLE
fix: Correct Go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/your-org/obi-scalp-bot
 
-go 1.24.3
+go 1.24
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect; testify dependency


### PR DESCRIPTION
The Go version was set to 1.24.3, which is an invalid format. This commit corrects the version to 1.24, which is the proper format.