### PR TITLE
Fix(optimizer): Penalize trials with no trades

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -178,12 +178,18 @@ def objective(trial):
     summary = run_simulation(temp_config_path, CURRENT_SIM_CSV_PATH)
     os.remove(temp_config_path)
 
-    if summary is None:
-        return 0.0, 0.0
+    if summary is None or summary.get('TotalTrades', 0) == 0:
+        # Penalize trials that result in no trades
+        return -1.0, -1.0
 
     # The metrics to optimize
     profit_factor = summary.get('ProfitFactor', 0.0)
     sharpe_ratio = summary.get('SharpeRatio', 0.0)
+
+    # Handle cases where PF is infinite (no losses)
+    if profit_factor > 1e6:
+        profit_factor = 1e6
+
     return profit_factor, sharpe_ratio
 
 


### PR DESCRIPTION
In the optimization process, it was observed that some parameter combinations result in zero trades, leading to a Profit Factor (PF) and Sharpe Ratio (SR) of 0.0. This provides no useful information to the optimizer and can cause it to get stuck in suboptimal regions of the parameter space.

This commit addresses the issue by modifying the `objective` function in `optimizer.py`. If a simulation run results in zero trades (i.e., `TotalTrades` in the summary is 0), the function now returns a penalty value of -1.0 for both PF and SR. This will guide the optimizer to avoid parameter sets that do not generate any trading activity, leading to a more effective and efficient search for profitable configurations.