### PR TITLE
Fix(optimizer): INTERVALの乗算を修正

### DIFF
--- a/optimizer/drift_monitor.py
+++ b/optimizer/drift_monitor.py
@@ -98,7 +98,7 @@ def get_performance_metrics(conn, hours):
             profit_factor,
             max_drawdown
         FROM pnl_reports
-        WHERE time >= NOW() - INTERVAL '%s hours'
+        WHERE time >= NOW() - INTERVAL '1 hour' * %s
         ORDER BY time DESC
         LIMIT 1;
     """


### PR DESCRIPTION
ドリフトモニターにおいて、時間間隔の計算に誤りがありました。
psycopg2でINTERVALと時間を乗算する際、`INTERVAL '%s hours'` という構文が正しく解釈されず、常に1時間として扱われていました。

このコミットでは、`INTERVAL '1 hour' * %s` という形式に修正し、時間間隔が正しく計算されるようにしました。 これにより、0.25時間のような小数値が指定された場合でも、意図した通りの期間（15分）でパフォーマンス指標が算出されるようになります。