### PR TITLE
Feat(report): PnLレポート生成を独立したマイクロサービスに分離

### DIFF
--- a/cmd/report/Dockerfile
+++ b/cmd/report/Dockerfile
@@ -1,0 +1,29 @@
+# --- Builder Stage ---
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies.
+RUN go mod download
+
+# Copy the source code
+COPY . .
+
+# Build the application
+# CGO_ENABLED=0 is important for creating a static binary
+# -o /app/report-generator specifies the output file name
+RUN CGO_ENABLED=0 go build -o /app/report-generator ./cmd/report
+
+# --- Final Stage ---
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/report-generator .
+
+# Command to run the application
+CMD ["./report-generator"]

--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -1,145 +1,102 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
+	"context"
+	"log"
 	"os"
 	"time"
 
-	"github.com/shopspring/decimal"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/your-org/obi-scalp-bot/internal/datastore"
+	"github.com/your-org/obi-scalp-bot/internal/report"
+	"github.com/your-org/obi-scalp-bot/pkg/logger"
 )
 
-// SimulationSummary はシミュレーション結果のサマリーです。
-type SimulationSummary struct {
-	TotalProfit         float64 `json:"TotalProfit"`
-	TotalTrades         int     `json:"TotalTrades"`
-	WinningTrades       int     `json:"WinningTrades"`
-	LosingTrades        int     `json:"LosingTrades"`
-	WinRate             float64 `json:"WinRate"`
-	LongWinningTrades   int     `json:"LongWinningTrades"`
-	LongLosingTrades    int     `json:"LongLosingTrades"`
-	LongWinRate         float64 `json:"LongWinRate"`
-	ShortWinningTrades  int     `json:"ShortWinningTrades"`
-	ShortLosingTrades   int     `json:"ShortLosingTrades"`
-	ShortWinRate        float64 `json:"ShortWinRate"`
-	AverageWin          float64 `json:"AverageWin"`
-	AverageLoss         float64 `json:"AverageLoss"`
-	RiskRewardRatio     float64 `json:"RiskRewardRatio"`
-	ProfitFactor        float64 `json:"ProfitFactor"`
-	MaxDrawdown         float64 `json:"MaxDrawdown"`
-	RecoveryFactor      float64 `json:"RecoveryFactor"`
-	SharpeRatio         float64 `json:"SharpeRatio"`
-	SortinoRatio        float64 `json:"SortinoRatio"`
-	CalmarRatio         float64 `json:"CalmarRatio"`
-	MaxConsecutiveWins  int     `json:"MaxConsecutiveWins"`
-	MaxConsecutiveLosses int    `json:"MaxConsecutiveLosses"`
-	AverageHoldingPeriodSeconds float64 `json:"average_holding_period_seconds"`
-	AverageWinningHoldingPeriodSeconds float64 `json:"average_winning_holding_period_seconds"`
-	AverageLosingHoldingPeriodSeconds  float64 `json:"average_losing_holding_period_seconds"`
-	BuyAndHoldReturn    float64 `json:"BuyAndHoldReturn"`
-	ReturnVsBuyAndHold  float64 `json:"ReturnVsBuyAndHold"`
-}
-
 func main() {
-	// 標準入力からJSONデータを読み込む
-	data, err := io.ReadAll(os.Stdin)
+	// --- Logger Setup ---
+	l, err := logger.NewLogger("report-generator")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading from stdin: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("Failed to create logger: %v", err)
+	}
+	defer l.Sync()
+
+	// --- Database Connection ---
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		l.Fatal("DATABASE_URL environment variable is not set.")
 	}
 
-	// JSONデータをパース
-	var summary SimulationSummary
-	if err := json.Unmarshal(data, &summary); err != nil {
-		fmt.Fprintf(os.Stderr, "Error unmarshaling json: %v\n", err)
-		os.Exit(1)
+	dbpool, err := pgxpool.New(context.Background(), dbURL)
+	if err != nil {
+		l.Fatalf("Unable to connect to database: %v", err)
+	}
+	defer dbpool.Close()
+
+	repo := datastore.NewRepository(dbpool)
+	reportService := report.NewService(dbpool)
+
+	// --- Ticker for Periodic Report Generation ---
+	// Read interval from environment variable, default to 1 hour
+	intervalStr := os.Getenv("REPORT_INTERVAL_MINUTES")
+	interval, err := time.ParseDuration(intervalStr + "m")
+	if err != nil || interval <= 0 {
+		interval = 1 * time.Hour
 	}
 
-	// レポートをコンソールに出力
-	printReport(summary)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 
-	// JSTの現在時刻を取得
-	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
-	now := time.Now().In(jst)
-	filename := fmt.Sprintf("report_%s.json", now.Format("20060102_150405"))
-	filepath := "./report/" + filename
+	l.Infof("Report generator started. Will run every %v.", interval)
 
-	// レポートをJSONファイルに出力
-	if err := writeReportToJSON(summary, filepath); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing JSON report: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Printf("Report successfully written to %s\n", filepath)
-}
+	// --- Initial Run ---
+	runReportGeneration(repo, reportService, l)
 
-// printReport は分析レポートをコンソールに出力します。
-func printReport(s SimulationSummary) {
-	fmt.Println("--- 損益分析レポート ---")
-	fmt.Println()
-	fmt.Println("--- 全体 ---")
-	fmt.Printf("約定済み取引数: %d\n", s.TotalTrades)
-	fmt.Println()
-	fmt.Println("--- 約定済み取引の分析 ---")
-	if s.TotalTrades > 0 {
-		fmt.Printf("勝ちトレード数: %d\n", s.WinningTrades)
-		fmt.Printf("負けトレード数: %d\n", s.LosingTrades)
-		fmt.Printf("勝率: %.2f%%\n", s.WinRate)
-		fmt.Printf("合計損益: %s\n", decimal.NewFromFloat(s.TotalProfit).StringFixed(2))
-		fmt.Printf("平均利益: %s\n", decimal.NewFromFloat(s.AverageWin).StringFixed(2))
-		fmt.Printf("平均損失: %s\n", decimal.NewFromFloat(s.AverageLoss).StringFixed(2))
-		fmt.Printf("リスクリワードレシオ: %.2f\n", s.RiskRewardRatio)
-		fmt.Println()
-		fmt.Println("--- ロング戦略 ---")
-		fmt.Printf("勝ちトレード数: %d\n", s.LongWinningTrades)
-		fmt.Printf("負けトレード数: %d\n", s.LongLosingTrades)
-		fmt.Printf("勝率: %.2f%%\n", s.LongWinRate)
-		fmt.Println()
-		fmt.Println("--- ショート戦略 ---")
-		fmt.Printf("勝ちトレード数: %d\n", s.ShortWinningTrades)
-		fmt.Printf("負けトレード数: %d\n", s.ShortLosingTrades)
-		fmt.Printf("勝率: %.2f%%\n", s.ShortWinRate)
-	} else {
-		fmt.Println("約定済みの取引はありません。")
-	}
-	fmt.Println()
-	fmt.Println("--- パフォーマンス指標 ---")
-	if s.TotalTrades > 0 {
-		fmt.Printf("プロフィットファクター: %.2f\n", s.ProfitFactor)
-		fmt.Printf("シャープレシオ: %.2f\n", s.SharpeRatio)
-		fmt.Printf("ソルティノレシオ: %.2f\n", s.SortinoRatio)
-		fmt.Printf("カルマーレシオ: %.2f\n", s.CalmarRatio)
-		fmt.Printf("最大ドローダウン: %s\n", decimal.NewFromFloat(s.MaxDrawdown).StringFixed(2))
-		fmt.Printf("リカバリーファクター: %.2f\n", s.RecoveryFactor)
-		fmt.Printf("平均保有期間: %.2f 秒\n", s.AverageHoldingPeriodSeconds)
-		fmt.Printf("勝ちトレードの平均保有期間: %.2f 秒\n", s.AverageWinningHoldingPeriodSeconds)
-		fmt.Printf("負けトレードの平均保有期間: %.2f 秒\n", s.AverageLosingHoldingPeriodSeconds)
-		fmt.Printf("最大連勝数: %d\n", s.MaxConsecutiveWins)
-		fmt.Printf("最大連敗数: %d\n", s.MaxConsecutiveLosses)
-		fmt.Printf("バイ・アンド・ホールドリターン: %s\n", decimal.NewFromFloat(s.BuyAndHoldReturn).StringFixed(2))
-		fmt.Printf("リターン vs バイ・アンド・ホールド: %s\n", decimal.NewFromFloat(s.ReturnVsBuyAndHold).StringFixed(2))
-	}
-	fmt.Println()
-	fmt.Println("----------------------")
-}
-
-// writeReportToJSON はレポートをJSONファイルに書き込みます。
-func writeReportToJSON(s SimulationSummary, filepath string) error {
-	// ディレクトリが存在しない場合は作成
-	dir := "./report"
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return err
+	// --- Main Loop ---
+	for {
+		select {
+		case <-ticker.C:
+			l.Info("--- Running Report Generation ---")
+			runReportGeneration(repo, reportService, l)
+		case <-context.Background().Done(): // Add a way to gracefully shutdown
+			l.Info("Shutting down report generator.")
+			return
 		}
 	}
+}
 
-	file, err := os.Create(filepath)
+// runReportGeneration fetches trades, analyzes them, and saves the report.
+func runReportGeneration(repo *datastore.Repository, reportService *report.Service, l *logger.Logger) {
+	ctx := context.Background()
+
+	// 1. Fetch all trades
+	trades, err := repo.FetchAllTradesForReport(ctx)
 	if err != nil {
-		return err
+		l.Errorf("Failed to fetch trades for report: %v", err)
+		return
 	}
-	defer file.Close()
+	if len(trades) == 0 {
+		l.Info("No trades to generate a report.")
+		return
+	}
 
-	encoder := json.NewEncoder(file)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(s)
+	// 2. Analyze trades
+	// We need to convert datastore.Trade to report.Trade
+	reportTrades := make([]report.Trade, len(trades))
+	for i, t := range trades {
+		reportTrades[i] = report.Trade(t)
+	}
+
+	analysisReport, err := reportService.AnalyzeTrades(reportTrades)
+	if err != nil {
+		l.Errorf("Failed to analyze trades: %v", err)
+		return
+	}
+
+	// 3. Save the report
+	if err := reportService.SavePnlReport(ctx, analysisReport); err != nil {
+		l.Errorf("Failed to save PnL report: %v", err)
+		return
+	}
+
+	l.Infof("Successfully generated and saved a new PnL report from %d trades.", len(trades))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,22 +90,19 @@ services:
   report-generator:
     build:
       context: .
-      dockerfile: Dockerfile
-      target: builder
-    container_name: report-generator
-    volumes:
-      - .:/app
-    working_dir: /app
+      dockerfile: cmd/report/Dockerfile
+    container_name: obi-scalp-report-generator
     env_file:
       - .env
+    environment:
+      - DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@timescaledb:${DB_PORT}/${DB_NAME}?sslmode=disable
+      - REPORT_INTERVAL_MINUTES=60
+    depends_on:
+      timescaledb:
+        condition: service_healthy
+    restart: unless-stopped
     networks:
       - bot_network
-    command: ["sleep", "infinity"]
-    healthcheck:
-      test: ["CMD-SHELL", "test -f /app/build/report"]
-      interval: 1s
-      timeout: 1s
-      retries: 5
 
   grafana:
     image: grafana/grafana-oss:latest

--- a/internal/datastore/repository.go
+++ b/internal/datastore/repository.go
@@ -10,72 +10,6 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// calculateStandardDeviation はリターンの標準偏差を計算します。
-func calculateStandardDeviation(returns []float64, mean float64) float64 {
-	if len(returns) == 0 {
-		return 0.0
-	}
-	variance := 0.0
-	for _, r := range returns {
-		variance += math.Pow(r-mean, 2)
-	}
-	return math.Sqrt(variance / float64(len(returns)))
-}
-
-// calculateDownsideDeviation は下方偏差を計算します。
-func calculateDownsideDeviation(returns []float64, target float64) float64 {
-	if len(returns) == 0 {
-		return 0.0
-	}
-	downsideVariance := 0.0
-	downsideCount := 0
-	for _, r := range returns {
-		if r < target {
-			downsideVariance += math.Pow(r-target, 2)
-			downsideCount++
-		}
-	}
-	if downsideCount == 0 {
-		return 0.0
-	}
-	return math.Sqrt(downsideVariance / float64(downsideCount))
-}
-
-// calculateSharpeRatio はシャープレシオを計算します。
-func calculateSharpeRatio(returns []float64, riskFreeRate float64) float64 {
-	if len(returns) == 0 {
-		return 0.0
-	}
-	mean := 0.0
-	for _, r := range returns {
-		mean += r
-	}
-	mean /= float64(len(returns))
-
-	stdDev := calculateStandardDeviation(returns, mean)
-	if stdDev == 0 {
-		return 0.0
-	}
-	return (mean - riskFreeRate) / stdDev
-}
-
-// calculateSortinoRatio はソルティノレシオを計算します。
-func calculateSortinoRatio(returns []float64, riskFreeRate float64) float64 {
-	if len(returns) == 0 {
-		return 0.0
-	}
-	mean := 0.0
-	for _, r := range returns {
-		mean += r
-	}
-	mean /= float64(len(returns))
-
-	downsideDev := calculateDownsideDeviation(returns, 0) // ターゲットリターンを0と仮定
-	if downsideDev == 0 {
-		return 0.0
-	}
-	return (mean - riskFreeRate) / downsideDev
-}
 
 // Repository handles database operations for fetching backtest data.
 type Repository struct {
@@ -96,41 +30,6 @@ type Trade struct {
 	Size            decimal.Decimal `json:"size"`
 	TransactionID   int64           `json:"transaction_id"`
 	IsCancelled     bool            `json:"is_cancelled"`
-}
-
-// Report は損益分析の結果を保持します。
-type Report struct {
-	StartDate                        time.Time       `json:"start_date"`
-	EndDate                          time.Time       `json:"end_date"`
-	TotalTrades                      int             `json:"total_trades"`        // Executed trades
-	CancelledTrades                  int             `json:"cancelled_trades"`    // Cancelled trades
-	CancellationRate                 float64         `json:"cancellation_rate"`   // Cancellation rate
-	WinningTrades                    int             `json:"winning_trades"`
-	LosingTrades                     int             `json:"losing_trades"`
-	WinRate                          float64         `json:"win_rate"`
-	LongWinningTrades                int             `json:"long_winning_trades"`
-	LongLosingTrades                 int             `json:"long_losing_trades"`
-	LongWinRate                      float64         `json:"long_win_rate"`
-	ShortWinningTrades               int             `json:"short_winning_trades"`
-	ShortLosingTrades                int             `json:"short_losing_trades"`
-	ShortWinRate                     float64         `json:"short_win_rate"`
-	TotalPnL                         decimal.Decimal `json:"total_pnl"`
-	AverageProfit                    decimal.Decimal `json:"average_profit"`
-	AverageLoss                      decimal.Decimal `json:"average_loss"`
-	RiskRewardRatio                  float64         `json:"risk_reward_ratio"`
-	ProfitFactor                     float64         `json:"profit_factor"`
-	MaxDrawdown                      decimal.Decimal `json:"max_drawdown"`
-	RecoveryFactor                   float64         `json:"recovery_factor"`
-	SharpeRatio                      float64         `json:"sharpe_ratio"`
-	SortinoRatio                     float64         `json:"sortino_ratio"`
-	CalmarRatio                      float64         `json:"calmar_ratio"`
-	MaxConsecutiveWins               int             `json:"max_consecutive_wins"`
-	MaxConsecutiveLosses             int             `json:"max_consecutive_losses"`
-	AverageHoldingPeriodSeconds      float64         `json:"average_holding_period_seconds"`
-	AverageWinningHoldingPeriodSeconds float64       `json:"average_winning_holding_period_seconds"`
-	AverageLosingHoldingPeriodSeconds  float64       `json:"average_losing_holding_period_seconds"`
-	BuyAndHoldReturn                 decimal.Decimal `json:"buy_and_hold_return"`
-	ReturnVsBuyAndHold               decimal.Decimal `json:"return_vs_buy_and_hold"`
 }
 
 // FetchAllTradesForReport はデータベースからすべてのトレードを取得します。
@@ -158,326 +57,6 @@ func (r *Repository) FetchAllTradesForReport(ctx context.Context) ([]Trade, erro
 	return trades, rows.Err()
 }
 
-// AnalyzeTrades はトレードリストを分析してレポートを作成します。
-func AnalyzeTrades(trades []Trade) (Report, error) {
-	if len(trades) == 0 {
-		return Report{}, fmt.Errorf("no trades to analyze")
-	}
-
-	var executedTrades []Trade
-	cancelledCount := 0
-	for _, t := range trades {
-		if t.IsCancelled {
-			cancelledCount++
-		} else {
-			executedTrades = append(executedTrades, t)
-		}
-	}
-
-	if len(executedTrades) == 0 {
-		return Report{
-			StartDate:       trades[0].Time,
-			EndDate:         trades[len(trades)-1].Time,
-			CancelledTrades: cancelledCount,
-			TotalTrades:     0,
-		}, nil
-	}
-
-	var buys, sells []Trade
-	var totalPnL decimal.Decimal
-	var longWinningTrades, longLosingTrades int
-	var shortWinningTrades, shortLosingTrades int
-	var totalProfit, totalLoss decimal.Decimal
-	var pnlHistory []decimal.Decimal
-	var holdingPeriods, winningHoldingPeriods, losingHoldingPeriods []float64
-	var consecutiveWins, consecutiveLosses, maxConsecutiveWins, maxConsecutiveLosses int
-
-	startDate := executedTrades[0].Time
-	endDate := executedTrades[len(executedTrades)-1].Time
-
-	for _, trade := range executedTrades {
-		if trade.Side == "buy" {
-			for len(sells) > 0 && trade.Size.IsPositive() {
-				sell := sells[0]
-				matchSize := decimal.Min(sell.Size, trade.Size)
-				pnl := sell.Price.Sub(trade.Price).Mul(matchSize)
-				totalPnL = totalPnL.Add(pnl)
-				pnlHistory = append(pnlHistory, pnl)
-				holdingPeriod := trade.Time.Sub(sell.Time).Seconds()
-				holdingPeriods = append(holdingPeriods, holdingPeriod)
-
-				if pnl.IsPositive() {
-					shortWinningTrades++
-					totalProfit = totalProfit.Add(pnl)
-					winningHoldingPeriods = append(winningHoldingPeriods, holdingPeriod)
-					consecutiveWins++
-					consecutiveLosses = 0
-					if consecutiveWins > maxConsecutiveWins {
-						maxConsecutiveWins = consecutiveWins
-					}
-				} else if pnl.IsNegative() {
-					shortLosingTrades++
-					totalLoss = totalLoss.Add(pnl)
-					losingHoldingPeriods = append(losingHoldingPeriods, holdingPeriod)
-					consecutiveLosses++
-					consecutiveWins = 0
-					if consecutiveLosses > maxConsecutiveLosses {
-						maxConsecutiveLosses = consecutiveLosses
-					}
-				}
-				sell.Size = sell.Size.Sub(matchSize)
-				trade.Size = trade.Size.Sub(matchSize)
-				if sell.Size.IsZero() {
-					sells = sells[1:]
-				} else {
-					sells[0] = sell
-				}
-			}
-			if trade.Size.IsPositive() {
-				buys = append(buys, trade)
-			}
-		} else if trade.Side == "sell" {
-			for len(buys) > 0 && trade.Size.IsPositive() {
-				buy := buys[0]
-				matchSize := decimal.Min(buy.Size, trade.Size)
-				pnl := trade.Price.Sub(buy.Price).Mul(matchSize)
-				totalPnL = totalPnL.Add(pnl)
-				pnlHistory = append(pnlHistory, pnl)
-				holdingPeriod := trade.Time.Sub(buy.Time).Seconds()
-				holdingPeriods = append(holdingPeriods, holdingPeriod)
-
-				if pnl.IsPositive() {
-					longWinningTrades++
-					totalProfit = totalProfit.Add(pnl)
-					winningHoldingPeriods = append(winningHoldingPeriods, holdingPeriod)
-					consecutiveWins++
-					consecutiveLosses = 0
-					if consecutiveWins > maxConsecutiveWins {
-						maxConsecutiveWins = consecutiveWins
-					}
-				} else if pnl.IsNegative() {
-					longLosingTrades++
-					totalLoss = totalLoss.Add(pnl)
-					losingHoldingPeriods = append(losingHoldingPeriods, holdingPeriod)
-					consecutiveLosses++
-					consecutiveWins = 0
-					if consecutiveLosses > maxConsecutiveLosses {
-						maxConsecutiveLosses = consecutiveLosses
-					}
-				}
-				buy.Size = buy.Size.Sub(matchSize)
-				trade.Size = trade.Size.Sub(matchSize)
-				if buy.Size.IsZero() {
-					buys = buys[1:]
-				} else {
-					buys[0] = buy
-				}
-			}
-			if trade.Size.IsPositive() {
-				sells = append(sells, trade)
-			}
-		}
-	}
-
-	winningTrades := longWinningTrades + shortWinningTrades
-	losingTrades := longLosingTrades + shortLosingTrades
-	totalExecutedTrades := winningTrades + losingTrades
-
-	cancellationRate := 0.0
-	if cancelledCount+totalExecutedTrades > 0 {
-		cancellationRate = float64(cancelledCount) / float64(cancelledCount+totalExecutedTrades) * 100
-	}
-
-	winRate := 0.0
-	if totalExecutedTrades > 0 {
-		winRate = float64(winningTrades) / float64(totalExecutedTrades) * 100
-	}
-
-	longWinRate := 0.0
-	if longWinningTrades+longLosingTrades > 0 {
-		longWinRate = float64(longWinningTrades) / float64(longWinningTrades+longLosingTrades) * 100
-	}
-
-	shortWinRate := 0.0
-	if shortWinningTrades+shortLosingTrades > 0 {
-		shortWinRate = float64(shortWinningTrades) / float64(shortWinningTrades+shortLosingTrades) * 100
-	}
-
-	avgProfit := decimal.Zero
-	if winningTrades > 0 {
-		avgProfit = totalProfit.Div(decimal.NewFromInt(int64(winningTrades)))
-	}
-
-	avgLoss := decimal.Zero
-	if losingTrades > 0 {
-		avgLoss = totalLoss.Div(decimal.NewFromInt(int64(losingTrades)))
-	}
-
-	riskRewardRatio := 0.0
-	if !avgLoss.IsZero() {
-		riskRewardRatio = avgProfit.Div(avgLoss.Abs()).InexactFloat64()
-	}
-
-	profitFactor := 0.0
-	if totalLoss.IsNegative() {
-		profitFactor = totalProfit.Div(totalLoss.Abs()).InexactFloat64()
-	}
-
-	// パフォーマンス指標の計算
-	equityCurve := make([]decimal.Decimal, len(pnlHistory)+1)
-	equityCurve[0] = decimal.Zero
-	for i, pnl := range pnlHistory {
-		equityCurve[i+1] = equityCurve[i].Add(pnl)
-	}
-
-	maxDrawdown := decimal.Zero
-	peak := decimal.Zero
-	for _, equity := range equityCurve {
-		if equity.GreaterThan(peak) {
-			peak = equity
-		}
-		drawdown := peak.Sub(equity)
-		if drawdown.GreaterThan(maxDrawdown) {
-			maxDrawdown = drawdown
-		}
-	}
-
-	recoveryFactor := 0.0
-	if maxDrawdown.IsPositive() {
-		recoveryFactor = totalPnL.Div(maxDrawdown).InexactFloat64()
-	}
-
-	// pnlHistory を []float64 に変換
-	pnlFloats := make([]float64, len(pnlHistory))
-	for i, pnl := range pnlHistory {
-		pnlFloats[i] = pnl.InexactFloat64()
-	}
-
-	sharpeRatio := calculateSharpeRatio(pnlFloats, 0.0)
-	sortinoRatio := calculateSortinoRatio(pnlFloats, 0.0)
-
-	calmarRatio := 0.0
-	if maxDrawdown.IsPositive() {
-		totalPnLFloat := totalPnL.InexactFloat64()
-		maxDrawdownFloat := maxDrawdown.InexactFloat64()
-		// 年率リターンを計算 (単純化のため、期間全体のリターンを使用)
-		// 正確な年率リターンを計算するには、取引期間が必要
-		durationYears := endDate.Sub(startDate).Hours() / 24 / 365.25
-		annualizedReturn := 0.0
-		if durationYears > 0 {
-			annualizedReturn = totalPnLFloat / durationYears
-		} else if totalExecutedTrades > 0 {
-			// 期間が1年未満の場合は、単純なリターンを使用
-			annualizedReturn = totalPnLFloat
-		}
-		calmarRatio = annualizedReturn / maxDrawdownFloat
-	}
-
-	avgHoldingPeriod := 0.0
-	if len(holdingPeriods) > 0 {
-		sum := 0.0
-		for _, h := range holdingPeriods {
-			sum += h
-		}
-		avgHoldingPeriod = sum / float64(len(holdingPeriods))
-	}
-
-	avgWinningHoldingPeriod := 0.0
-	if len(winningHoldingPeriods) > 0 {
-		sum := 0.0
-		for _, h := range winningHoldingPeriods {
-			sum += h
-		}
-		avgWinningHoldingPeriod = sum / float64(len(winningHoldingPeriods))
-	}
-
-	avgLosingHoldingPeriod := 0.0
-	if len(losingHoldingPeriods) > 0 {
-		sum := 0.0
-		for _, h := range losingHoldingPeriods {
-			sum += h
-		}
-		avgLosingHoldingPeriod = sum / float64(len(losingHoldingPeriods))
-	}
-
-	buyAndHoldReturn := decimal.Zero
-	if len(executedTrades) > 1 {
-		initialPrice := executedTrades[0].Price
-		finalPrice := executedTrades[len(executedTrades)-1].Price
-		if initialPrice.IsPositive() {
-			buyAndHoldReturn = finalPrice.Sub(initialPrice).Div(initialPrice)
-		}
-	}
-
-	returnVsBuyAndHold := totalPnL.Sub(buyAndHoldReturn)
-
-	return Report{
-		StartDate:                        startDate,
-		EndDate:                          endDate,
-		TotalTrades:                      totalExecutedTrades,
-		CancelledTrades:                  cancelledCount,
-		CancellationRate:                 cancellationRate,
-		WinningTrades:                    winningTrades,
-		LosingTrades:                     losingTrades,
-		WinRate:                          winRate,
-		LongWinningTrades:                longWinningTrades,
-		LongLosingTrades:                 longLosingTrades,
-		LongWinRate:                      longWinRate,
-		ShortWinningTrades:               shortWinningTrades,
-		ShortLosingTrades:                shortLosingTrades,
-		ShortWinRate:                     shortWinRate,
-		TotalPnL:                         totalPnL,
-		AverageProfit:                    avgProfit,
-		AverageLoss:                      avgLoss,
-		RiskRewardRatio:                  riskRewardRatio,
-		ProfitFactor:                     profitFactor,
-		MaxDrawdown:                      maxDrawdown,
-		RecoveryFactor:                   recoveryFactor,
-		SharpeRatio:                      sharpeRatio,
-		SortinoRatio:                     sortinoRatio,
-		CalmarRatio:                      calmarRatio,
-		MaxConsecutiveWins:               maxConsecutiveWins,
-		MaxConsecutiveLosses:             maxConsecutiveLosses,
-		AverageHoldingPeriodSeconds:      avgHoldingPeriod,
-		AverageWinningHoldingPeriodSeconds: avgWinningHoldingPeriod,
-		AverageLosingHoldingPeriodSeconds:  avgLosingHoldingPeriod,
-		BuyAndHoldReturn:                 buyAndHoldReturn,
-		ReturnVsBuyAndHold:               returnVsBuyAndHold,
-	}, nil
-}
-
-// SavePnlReport は分析レポートをデータベースに保存します。
-func (r *Repository) SavePnlReport(ctx context.Context, report Report) error {
-	query := `
-        INSERT INTO pnl_reports (
-            time, start_date, end_date, total_trades, cancelled_trades,
-            cancellation_rate, winning_trades, losing_trades, win_rate,
-            long_winning_trades, long_losing_trades, long_win_rate,
-            short_winning_trades, short_losing_trades, short_win_rate,
-            total_pnl, average_profit, average_loss, risk_reward_ratio,
-            profit_factor, max_drawdown, recovery_factor, sharpe_ratio,
-            sortino_ratio, calmar_ratio, max_consecutive_wins, max_consecutive_losses,
-            average_holding_period_seconds, average_winning_holding_period_seconds,
-            average_losing_holding_period_seconds, buy_and_hold_return, return_vs_buy_and_hold
-        ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
-            $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32
-        );
-    `
-	_, err := r.db.Exec(ctx, query,
-		time.Now(), report.StartDate, report.EndDate, report.TotalTrades, report.CancelledTrades,
-		report.CancellationRate, report.WinningTrades, report.LosingTrades, report.WinRate,
-		report.LongWinningTrades, report.LongLosingTrades, report.LongWinRate,
-		report.ShortWinningTrades, report.ShortLosingTrades, report.ShortWinRate,
-		report.TotalPnL, report.AverageProfit, report.AverageLoss, report.RiskRewardRatio,
-		report.ProfitFactor, report.MaxDrawdown, report.RecoveryFactor, report.SharpeRatio,
-		report.SortinoRatio, report.CalmarRatio, report.MaxConsecutiveWins, report.MaxConsecutiveLosses,
-		report.AverageHoldingPeriodSeconds, report.AverageWinningHoldingPeriodSeconds,
-		report.AverageLosingHoldingPeriodSeconds, report.BuyAndHoldReturn, report.ReturnVsBuyAndHold,
-	)
-	return err
-}
-
 // DeleteOldPnlReports は指定した期間より古いPnLレポートを削除します。
 func (r *Repository) DeleteOldPnlReports(ctx context.Context, maxAgeHours int) (int64, error) {
 	threshold := time.Now().Add(-time.Duration(maxAgeHours) * time.Hour)
@@ -492,38 +71,33 @@ func (r *Repository) DeleteOldPnlReports(ctx context.Context, maxAgeHours int) (
 	return result.RowsAffected(), nil
 }
 
-// FetchLatestPnlReport は最新のPnLレポートを取得します。
-func (r *Repository) FetchLatestPnlReport(ctx context.Context) (*Report, error) {
+// PerformanceMetrics はドリフトモニターが必要とする主要なパフォーマンス指標を保持します。
+type PerformanceMetrics struct {
+	SharpeRatio  float64
+	ProfitFactor float64
+	MaxDrawdown  decimal.Decimal
+}
+
+// FetchLatestPerformanceMetrics は最新のパフォーマンス指標を取得します。
+func (r *Repository) FetchLatestPerformanceMetrics(ctx context.Context) (*PerformanceMetrics, error) {
 	query := `
         SELECT
-            start_date, end_date, total_trades, cancelled_trades,
-            cancellation_rate, winning_trades, losing_trades, win_rate,
-            long_winning_trades, long_losing_trades, long_win_rate,
-            short_winning_trades, short_losing_trades, short_win_rate,
-            total_pnl, average_profit, average_loss, risk_reward_ratio,
-            profit_factor, max_drawdown, recovery_factor, sharpe_ratio,
-            sortino_ratio, calmar_ratio, max_consecutive_wins, max_consecutive_losses,
-            average_holding_period_seconds, average_winning_holding_period_seconds,
-            average_losing_holding_period_seconds, buy_and_hold_return, return_vs_buy_and_hold
+            sharpe_ratio,
+            profit_factor,
+            max_drawdown
         FROM pnl_reports
         ORDER BY time DESC
         LIMIT 1;
     `
 	row := r.db.QueryRow(ctx, query)
-	var report Report
+	var metrics PerformanceMetrics
 	err := row.Scan(
-		&report.StartDate, &report.EndDate, &report.TotalTrades, &report.CancelledTrades,
-		&report.CancellationRate, &report.WinningTrades, &report.LosingTrades, &report.WinRate,
-		&report.LongWinningTrades, &report.LongLosingTrades, &report.LongWinRate,
-		&report.ShortWinningTrades, &report.ShortLosingTrades, &report.ShortWinRate,
-		&report.TotalPnL, &report.AverageProfit, &report.AverageLoss, &report.RiskRewardRatio,
-		&report.ProfitFactor, &report.MaxDrawdown, &report.RecoveryFactor, &report.SharpeRatio,
-		&report.SortinoRatio, &report.CalmarRatio, &report.MaxConsecutiveWins, &report.MaxConsecutiveLosses,
-		&report.AverageHoldingPeriodSeconds, &report.AverageWinningHoldingPeriodSeconds,
-		&report.AverageLosingHoldingPeriodSeconds, &report.BuyAndHoldReturn, &report.ReturnVsBuyAndHold,
+		&metrics.SharpeRatio,
+		&metrics.ProfitFactor,
+		&metrics.MaxDrawdown,
 	)
 	if err != nil {
 		return nil, err
 	}
-	return &report, nil
+	return &metrics, nil
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,454 @@
+package report
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Trade はデータベースからの取引を表します。
+type Trade struct {
+	Time            time.Time       `json:"time"`
+	Pair            string          `json:"pair"`
+	Side            string          `json:"side"`
+	Price           decimal.Decimal `json:"price"`
+	Size            decimal.Decimal `json:"size"`
+	TransactionID   int64           `json:"transaction_id"`
+	IsCancelled     bool            `json:"is_cancelled"`
+}
+
+// Report は損益分析の結果を保持します。
+type Report struct {
+	StartDate                        time.Time       `json:"start_date"`
+	EndDate                          time.Time       `json:"end_date"`
+	TotalTrades                      int             `json:"total_trades"`        // Executed trades
+	CancelledTrades                  int             `json:"cancelled_trades"`    // Cancelled trades
+	CancellationRate                 float64         `json:"cancellation_rate"`   // Cancellation rate
+	WinningTrades                    int             `json:"winning_trades"`
+	LosingTrades                     int             `json:"losing_trades"`
+	WinRate                          float64         `json:"win_rate"`
+	LongWinningTrades                int             `json:"long_winning_trades"`
+	LongLosingTrades                 int             `json:"long_losing_trades"`
+	LongWinRate                      float64         `json:"long_win_rate"`
+	ShortWinningTrades               int             `json:"short_winning_trades"`
+	ShortLosingTrades                int             `json:"short_losing_trades"`
+	ShortWinRate                     float64         `json:"short_win_rate"`
+	TotalPnL                         decimal.Decimal `json:"total_pnl"`
+	AverageProfit                    decimal.Decimal `json:"average_profit"`
+	AverageLoss                      decimal.Decimal `json:"average_loss"`
+	RiskRewardRatio                  float64         `json:"risk_reward_ratio"`
+	ProfitFactor                     float64         `json:"profit_factor"`
+	MaxDrawdown                      decimal.Decimal `json:"max_drawdown"`
+	RecoveryFactor                   float64         `json:"recovery_factor"`
+	SharpeRatio                      float64         `json:"sharpe_ratio"`
+	SortinoRatio                     float64         `json:"sortino_ratio"`
+	CalmarRatio                      float64         `json:"calmar_ratio"`
+	MaxConsecutiveWins               int             `json:"max_consecutive_wins"`
+	MaxConsecutiveLosses             int             `json:"max_consecutive_losses"`
+	AverageHoldingPeriodSeconds      float64         `json:"average_holding_period_seconds"`
+	AverageWinningHoldingPeriodSeconds float64       `json:"average_winning_holding_period_seconds"`
+	AverageLosingHoldingPeriodSeconds  float64       `json:"average_losing_holding_period_seconds"`
+	BuyAndHoldReturn                 decimal.Decimal `json:"buy_and_hold_return"`
+	ReturnVsBuyAndHold               decimal.Decimal `json:"return_vs_buy_and_hold"`
+}
+
+// Service handles report generation.
+type Service struct {
+	db *pgxpool.Pool
+}
+
+// NewService creates a new report service.
+func NewService(db *pgxpool.Pool) *Service {
+	return &Service{db: db}
+}
+
+// AnalyzeTrades はトレードリストを分析してレポートを作成します。
+func (s *Service) AnalyzeTrades(trades []Trade) (Report, error) {
+	if len(trades) == 0 {
+		return Report{}, fmt.Errorf("no trades to analyze")
+	}
+
+	var executedTrades []Trade
+	cancelledCount := 0
+	for _, t := range trades {
+		if t.IsCancelled {
+			cancelledCount++
+		} else {
+			executedTrades = append(executedTrades, t)
+		}
+	}
+
+	if len(executedTrades) == 0 {
+		return Report{
+			StartDate:       trades[0].Time,
+			EndDate:         trades[len(trades)-1].Time,
+			CancelledTrades: cancelledCount,
+			TotalTrades:     0,
+		}, nil
+	}
+
+	var buys, sells []Trade
+	var totalPnL decimal.Decimal
+	var longWinningTrades, longLosingTrades int
+	var shortWinningTrades, shortLosingTrades int
+	var totalProfit, totalLoss decimal.Decimal
+	var pnlHistory []decimal.Decimal
+	var holdingPeriods, winningHoldingPeriods, losingHoldingPeriods []float64
+	var consecutiveWins, consecutiveLosses, maxConsecutiveWins, maxConsecutiveLosses int
+
+	startDate := executedTrades[0].Time
+	endDate := executedTrades[len(executedTrades)-1].Time
+
+	for _, trade := range executedTrades {
+		if trade.Side == "buy" {
+			for len(sells) > 0 && trade.Size.IsPositive() {
+				sell := sells[0]
+				matchSize := decimal.Min(sell.Size, trade.Size)
+				pnl := sell.Price.Sub(trade.Price).Mul(matchSize)
+				totalPnL = totalPnL.Add(pnl)
+				pnlHistory = append(pnlHistory, pnl)
+				holdingPeriod := trade.Time.Sub(sell.Time).Seconds()
+				holdingPeriods = append(holdingPeriods, holdingPeriod)
+
+				if pnl.IsPositive() {
+					shortWinningTrades++
+					totalProfit = totalProfit.Add(pnl)
+					winningHoldingPeriods = append(winningHoldingPeriods, holdingPeriod)
+					consecutiveWins++
+					consecutiveLosses = 0
+					if consecutiveWins > maxConsecutiveWins {
+						maxConsecutiveWins = consecutiveWins
+					}
+				} else if pnl.IsNegative() {
+					shortLosingTrades++
+					totalLoss = totalLoss.Add(pnl)
+					losingHoldingPeriods = append(losingHoldingPeriods, holdingPeriod)
+					consecutiveLosses++
+					consecutiveWins = 0
+					if consecutiveLosses > maxConsecutiveLosses {
+						maxConsecutiveLosses = consecutiveLosses
+					}
+				}
+				sell.Size = sell.Size.Sub(matchSize)
+				trade.Size = trade.Size.Sub(matchSize)
+				if sell.Size.IsZero() {
+					sells = sells[1:]
+				} else {
+					sells[0] = sell
+				}
+			}
+			if trade.Size.IsPositive() {
+				buys = append(buys, trade)
+			}
+		} else if trade.Side == "sell" {
+			for len(buys) > 0 && trade.Size.IsPositive() {
+				buy := buys[0]
+				matchSize := decimal.Min(buy.Size, trade.Size)
+				pnl := trade.Price.Sub(buy.Price).Mul(matchSize)
+				totalPnL = totalPnL.Add(pnl)
+				pnlHistory = append(pnlHistory, pnl)
+				holdingPeriod := trade.Time.Sub(buy.Time).Seconds()
+				holdingPeriods = append(holdingPeriods, holdingPeriod)
+
+				if pnl.IsPositive() {
+					longWinningTrades++
+					totalProfit = totalProfit.Add(pnl)
+					winningHoldingPeriods = append(winningHoldingPeriods, holdingPeriod)
+					consecutiveWins++
+					consecutiveLosses = 0
+					if consecutiveWins > maxConsecutiveWins {
+						maxConsecutiveWins = consecutiveWins
+					}
+				} else if pnl.IsNegative() {
+					longLosingTrades++
+					totalLoss = totalLoss.Add(pnl)
+					losingHoldingPeriods = append(losingHoldingPeriods, holdingPeriod)
+					consecutiveLosses++
+					consecutiveWins = 0
+					if consecutiveLosses > maxConsecutiveLosses {
+						maxConsecutiveLosses = consecutiveLosses
+					}
+				}
+				buy.Size = buy.Size.Sub(matchSize)
+				trade.Size = trade.Size.Sub(matchSize)
+				if buy.Size.IsZero() {
+					buys = buys[1:]
+				} else {
+					buys[0] = buy
+				}
+			}
+			if trade.Size.IsPositive() {
+				sells = append(sells, trade)
+			}
+		}
+	}
+
+	winningTrades := longWinningTrades + shortWinningTrades
+	losingTrades := longLosingTrades + shortLosingTrades
+	totalExecutedTrades := winningTrades + losingTrades
+
+	cancellationRate := 0.0
+	if cancelledCount+totalExecutedTrades > 0 {
+		cancellationRate = float64(cancelledCount) / float64(cancelledCount+totalExecutedTrades) * 100
+	}
+
+	winRate := 0.0
+	if totalExecutedTrades > 0 {
+		winRate = float64(winningTrades) / float64(totalExecutedTrades) * 100
+	}
+
+	longWinRate := 0.0
+	if longWinningTrades+longLosingTrades > 0 {
+		longWinRate = float64(longWinningTrades) / float64(longWinningTrades+longLosingTrades) * 100
+	}
+
+	shortWinRate := 0.0
+	if shortWinningTrades+shortLosingTrades > 0 {
+		shortWinRate = float64(shortWinningTrades) / float64(shortWinningTrades+shortLosingTrades) * 100
+	}
+
+	avgProfit := decimal.Zero
+	if winningTrades > 0 {
+		avgProfit = totalProfit.Div(decimal.NewFromInt(int64(winningTrades)))
+	}
+
+	avgLoss := decimal.Zero
+	if losingTrades > 0 {
+		avgLoss = totalLoss.Div(decimal.NewFromInt(int64(losingTrades)))
+	}
+
+	riskRewardRatio := 0.0
+	if !avgLoss.IsZero() {
+		riskRewardRatio = avgProfit.Div(avgLoss.Abs()).InexactFloat64()
+	}
+
+	profitFactor := 0.0
+	if totalLoss.IsNegative() {
+		profitFactor = totalProfit.Div(totalLoss.Abs()).InexactFloat64()
+	}
+
+	// パフォーマンス指標の計算
+	equityCurve := make([]decimal.Decimal, len(pnlHistory)+1)
+	equityCurve[0] = decimal.Zero
+	for i, pnl := range pnlHistory {
+		equityCurve[i+1] = equityCurve[i].Add(pnl)
+	}
+
+	maxDrawdown := decimal.Zero
+	peak := decimal.Zero
+	for _, equity := range equityCurve {
+		if equity.GreaterThan(peak) {
+			peak = equity
+		}
+		drawdown := peak.Sub(equity)
+		if drawdown.GreaterThan(maxDrawdown) {
+			maxDrawdown = drawdown
+		}
+	}
+
+	recoveryFactor := 0.0
+	if maxDrawdown.IsPositive() {
+		recoveryFactor = totalPnL.Div(maxDrawdown).InexactFloat64()
+	}
+
+	// pnlHistory を []float64 に変換
+	pnlFloats := make([]float64, len(pnlHistory))
+	for i, pnl := range pnlHistory {
+		pnlFloats[i] = pnl.InexactFloat64()
+	}
+
+	sharpeRatio := calculateSharpeRatio(pnlFloats, 0.0)
+	sortinoRatio := calculateSortinoRatio(pnlFloats, 0.0)
+
+	calmarRatio := 0.0
+	if maxDrawdown.IsPositive() {
+		totalPnLFloat := totalPnL.InexactFloat64()
+		maxDrawdownFloat := maxDrawdown.InexactFloat64()
+		// 年率リターンを計算 (単純化のため、期間全体のリターンを使用)
+		// 正確な年率リターンを計算するには、取引期間が必要
+		durationYears := endDate.Sub(startDate).Hours() / 24 / 365.25
+		annualizedReturn := 0.0
+		if durationYears > 0 {
+			annualizedReturn = totalPnLFloat / durationYears
+		} else if totalExecutedTrades > 0 {
+			// 期間が1年未満の場合は、単純なリターンを使用
+			annualizedReturn = totalPnLFloat
+		}
+		calmarRatio = annualizedReturn / maxDrawdownFloat
+	}
+
+	avgHoldingPeriod := 0.0
+	if len(holdingPeriods) > 0 {
+		sum := 0.0
+		for _, h := range holdingPeriods {
+			sum += h
+		}
+		avgHoldingPeriod = sum / float64(len(holdingPeriods))
+	}
+
+	avgWinningHoldingPeriod := 0.0
+	if len(winningHoldingPeriods) > 0 {
+		sum := 0.0
+		for _, h := range winningHoldingPeriods {
+			sum += h
+		}
+		avgWinningHoldingPeriod = sum / float64(len(winningHoldingPeriods))
+	}
+
+	avgLosingHoldingPeriod := 0.0
+	if len(losingHoldingPeriods) > 0 {
+		sum := 0.0
+		for _, h := range losingHoldingPeriods {
+			sum += h
+		}
+		avgLosingHoldingPeriod = sum / float64(len(losingHoldingPeriods))
+	}
+
+	buyAndHoldReturn := decimal.Zero
+	if len(executedTrades) > 1 {
+		initialPrice := executedTrades[0].Price
+		finalPrice := executedTrades[len(executedTrades)-1].Price
+		if initialPrice.IsPositive() {
+			buyAndHoldReturn = finalPrice.Sub(initialPrice).Div(initialPrice)
+		}
+	}
+
+	returnVsBuyAndHold := totalPnL.Sub(buyAndHoldReturn)
+
+	return Report{
+		StartDate:                        startDate,
+		EndDate:                          endDate,
+		TotalTrades:                      totalExecutedTrades,
+		CancelledTrades:                  cancelledCount,
+		CancellationRate:                 cancellationRate,
+		WinningTrades:                    winningTrades,
+		LosingTrades:                     losingTrades,
+		WinRate:                          winRate,
+		LongWinningTrades:                longWinningTrades,
+		LongLosingTrades:                 longLosingTrades,
+		LongWinRate:                      longWinRate,
+		ShortWinningTrades:               shortWinningTrades,
+		ShortLosingTrades:                shortLosingTrades,
+		ShortWinRate:                     shortWinRate,
+		TotalPnL:                         totalPnL,
+		AverageProfit:                    avgProfit,
+		AverageLoss:                      avgLoss,
+		RiskRewardRatio:                  riskRewardRatio,
+		ProfitFactor:                     profitFactor,
+		MaxDrawdown:                      maxDrawdown,
+		RecoveryFactor:                   recoveryFactor,
+		SharpeRatio:                      sharpeRatio,
+		SortinoRatio:                     sortinoRatio,
+		CalmarRatio:                      calmarRatio,
+		MaxConsecutiveWins:               maxConsecutiveWins,
+		MaxConsecutiveLosses:             maxConsecutiveLosses,
+		AverageHoldingPeriodSeconds:      avgHoldingPeriod,
+		AverageWinningHoldingPeriodSeconds: avgWinningHoldingPeriod,
+		AverageLosingHoldingPeriodSeconds:  avgLosingHoldingPeriod,
+		BuyAndHoldReturn:                 buyAndHoldReturn,
+		ReturnVsBuyAndHold:               returnVsBuyAndHold,
+	}, nil
+}
+
+// SavePnlReport は分析レポートをデータベースに保存します。
+func (s *Service) SavePnlReport(ctx context.Context, report Report) error {
+	query := `
+        INSERT INTO pnl_reports (
+            time, start_date, end_date, total_trades, cancelled_trades,
+            cancellation_rate, winning_trades, losing_trades, win_rate,
+            long_winning_trades, long_losing_trades, long_win_rate,
+            short_winning_trades, short_losing_trades, short_win_rate,
+            total_pnl, average_profit, average_loss, risk_reward_ratio,
+            profit_factor, max_drawdown, recovery_factor, sharpe_ratio,
+            sortino_ratio, calmar_ratio, max_consecutive_wins, max_consecutive_losses,
+            average_holding_period_seconds, average_winning_holding_period_seconds,
+            average_losing_holding_period_seconds, buy_and_hold_return, return_vs_buy_and_hold
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
+            $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32
+        );
+    `
+	_, err := s.db.Exec(ctx, query,
+		time.Now(), report.StartDate, report.EndDate, report.TotalTrades, report.CancelledTrades,
+		report.CancellationRate, report.WinningTrades, report.LosingTrades, report.WinRate,
+		report.LongWinningTrades, report.LongLosingTrades, report.LongWinRate,
+		report.ShortWinningTrades, report.ShortLosingTrades, report.ShortWinRate,
+		report.TotalPnL, report.AverageProfit, report.AverageLoss, report.RiskRewardRatio,
+		report.ProfitFactor, report.MaxDrawdown, report.RecoveryFactor, report.SharpeRatio,
+		report.SortinoRatio, report.CalmarRatio, report.MaxConsecutiveWins, report.MaxConsecutiveLosses,
+		report.AverageHoldingPeriodSeconds, report.AverageWinningHoldingPeriodSeconds,
+		report.AverageLosingHoldingPeriodSeconds, report.BuyAndHoldReturn, report.ReturnVsBuyAndHold,
+	)
+	return err
+}
+
+// calculateStandardDeviation はリターンの標準偏差を計算します。
+func calculateStandardDeviation(returns []float64, mean float64) float64 {
+	if len(returns) == 0 {
+		return 0.0
+	}
+	variance := 0.0
+	for _, r := range returns {
+		variance += math.Pow(r-mean, 2)
+	}
+	return math.Sqrt(variance / float64(len(returns)))
+}
+
+// calculateDownsideDeviation は下方偏差を計算します。
+func calculateDownsideDeviation(returns []float64, target float64) float64 {
+	if len(returns) == 0 {
+		return 0.0
+	}
+	downsideVariance := 0.0
+	downsideCount := 0
+	for _, r := range returns {
+		if r < target {
+			downsideVariance += math.Pow(r-target, 2)
+			downsideCount++
+		}
+	}
+	if downsideCount == 0 {
+		return 0.0
+	}
+	return math.Sqrt(downsideVariance / float64(downsideCount))
+}
+
+// calculateSharpeRatio はシャープレシオを計算します。
+func calculateSharpeRatio(returns []float64, riskFreeRate float64) float64 {
+	if len(returns) == 0 {
+		return 0.0
+	}
+	mean := 0.0
+	for _, r := range returns {
+		mean += r
+	}
+	mean /= float64(len(returns))
+
+	stdDev := calculateStandardDeviation(returns, mean)
+	if stdDev == 0 {
+		return 0.0
+	}
+	return (mean - riskFreeRate) / stdDev
+}
+
+// calculateSortinoRatio はソルティノレシオを計算します。
+func calculateSortinoRatio(returns []float64, riskFreeRate float64) float64 {
+	if len(returns) == 0 {
+		return 0.0
+	}
+	mean := 0.0
+	for _, r := range returns {
+		mean += r
+	}
+	mean /= float64(len(returns))
+
+	downsideDev := calculateDownsideDeviation(returns, 0) // ターゲットリターンを0と仮定
+	if downsideDev == 0 {
+		return 0.0
+	}
+	return (mean - riskFreeRate) / downsideDev
+}

--- a/optimizer/drift_monitor.py
+++ b/optimizer/drift_monitor.py
@@ -98,7 +98,7 @@ def get_performance_metrics(conn, hours):
             profit_factor,
             max_drawdown
         FROM pnl_reports
-        WHERE time >= NOW() - INTERVAL '%s hours'
+        WHERE time >= NOW() - INTERVAL '1 hour' * %s
         ORDER BY time DESC
         LIMIT 1;
     """


### PR DESCRIPTION
これまで `datastore` に混在していたPnLレポートの生成ロジックを、独立した `report-generator` マイクロサービスに分離しました。

主な変更点：
- `cmd/report/main.go`: 新しいレポート生成サービスのエントリーポイント。定期的に `trades` テーブルからデータを集計し、`pnl_reports` テーブルに保存します。
- `internal/report`: レポートの分析・保存ロジックを格納する新しいパッケージ。
- `internal/datastore`: レポート生成関連の責務を `internal/report` に移譲し、関連コードを削除。
- `docker-compose.yml`: `report-generator` サービスを定義し、独立したコンテナとして実行されるように設定。
- `cmd/report/Dockerfile`: `report-generator` サービスをビルドするためのDockerfile。

この変更により、関心の分離が促進され、各サービスの責務が明確になりました。メンテナンス性とスケーラビリティが向上し、今後の機能追加や修正が容易になります。