### PR TITLE
Fix(build): go mod tidyを実行して依存関係を整理

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/your-org/obi-scalp-bot
 
-go 1.21
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect; testify dependency
@@ -16,7 +18,8 @@ require (
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0
-	github.com/google/uuid v1.6.0
+	github.com/fsnotify/fsnotify v1.9.0
+	github.com/go-chi/chi/v5 v5.2.2
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/rodrigo-brito/hurst v1.0.0
 	github.com/shopspring/decimal v1.4.0
@@ -41,12 +44,11 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect


### PR DESCRIPTION
ビルド時に "go: updates to go.mod needed" というエラーが発生していたため、`go mod tidy` を実行しました。

これにより、`go.mod` と `go.sum` がプロジェクトの実際の依存関係と一致するように更新され、ビルドエラーが解消されます。