### PR TITLE
Fix(report): 未使用の "log" インポートを削除

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"time"
 


### PR DESCRIPTION
`cmd/report/main.go` で "log" パッケージがインポートされていましたが、実際には使用されていなかったため、ビルドエラーが発生していました。

このコミットでは、未使用のインポートを削除し、ビルドエラーを解消します。