### PR TITLE
Fix(report): Dockerfileのベースイメージをalpine:3.19に変更

### DIFF
--- a/cmd/report/Dockerfile
+++ b/cmd/report/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /app/report-generator ./cmd/report
 
 # --- Final Stage ---
-FROM alpine:latest
+FROM alpine:3.19
 
 WORKDIR /app
 


### PR DESCRIPTION
ビルド時に`alpine:latest`の取得でTLS handshake timeoutが発生していたため、ベースイメージを特定のバージョン(`alpine:3.19`)に固定しました。

これにより、Docker Hubのキャッシュの問題や一時的なネットワークの不安定性を回避し、ビルドの安定性を向上させることが期待されます。