### PR TITLE
Fix(build): go.modにreplaceディレクティブを追加

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.23.0
 
 toolchain go1.24.3
 
+replace github.com/your-org/obi-scalp-bot => ./
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect; testify dependency
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
ローカルパッケージの依存関係が解決できず、ビルドエラーが発生していました。

この問題を解決するため、`go.mod`に`replace`ディレクティブを追加し、モジュールがローカルパスにあることを明示的に指定しました。

```
replace github.com/your-org/obi-scalp-bot => ./
```

これにより、ビルド時にローカルパッケージが正しく解決されるようになります。