### PR TITLE
feat: Optimize Optuna performance and configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     working_dir: /app
     environment:
       - DB_HOST=timescaledb
+      - STORAGE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@timescaledb:5432/${DB_NAME}
     networks:
       - bot_network
     depends_on:
@@ -150,6 +151,7 @@ services:
       - .env
     environment:
       - DB_HOST=timescaledb
+      - STORAGE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@timescaledb:5432/${DB_NAME}
     networks:
       - bot_network
     depends_on:

--- a/optimizer/Dockerfile
+++ b/optimizer/Dockerfile
@@ -23,5 +23,12 @@ WORKDIR /app
 COPY optimizer/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Set environment variables to control thread usage by numerical libraries
+ENV OMP_NUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    VECLIB_MAXIMUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1
+
 # Copy the entire source code
 COPY . .


### PR DESCRIPTION
This commit implements three major improvements to the optimization process:

1.  **Migrate Optuna Storage to PostgreSQL**: The storage backend for Optuna has been switched from SQLite to PostgreSQL (TimescaleDB). This resolves file locking issues encountered with SQLite in multi-process environments and allows for horizontal scaling of optimizer instances. The `STORAGE_URL` is now configured via environment variables in `docker-compose.yml`.

2.  **Control OMP Threads**: To prevent CPU over-subscription caused by nested parallelism (Optuna's `n_jobs=-1` and NumPy/OpenBLAS's internal threading), environment variables (`OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, etc.) have been added to the `optimizer/Dockerfile` to limit intra-process thread usage to 1. This should improve overall throughput by reducing thread contention.

3.  **Enable Early Pruning with HyperbandPruner**: `HyperbandPruner` has been introduced to enable early termination of unpromising trials. This significantly reduces wasted computation time by stopping poor-performing parameter sets before they complete the full simulation. The `objective` function has been updated to report intermediate values to the pruner.