### PR TITLE
Fix: Change optimizer restart policy to always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       timeout: 5s
       retries: 12
       start_period: 5s
-    restart: on-failure
+    restart: always
 
   drift-monitor:
     build:


### PR DESCRIPTION
To address the issue where the optimizer container would not restart upon encountering an error, I have modified the restart policy in `docker-compose.yml` from `on-failure` to `always`. This change will enhance the availability of the container.