### PR TITLE
fix: Set explicit max_resource for HyperbandPruner

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -370,7 +370,7 @@ def main():
 
             pruner = HyperbandPruner(
                 min_resource=1,
-                max_resource='auto',
+                max_resource=100,
                 reduction_factor=3
             )
             study = optuna.create_study(


### PR DESCRIPTION
Sets an explicit `max_resource` for the `HyperbandPruner` to avoid an `AssertionError: This line should be unreachable.` that occurs when `max_resource` is set to `'auto'`.