### PR TITLE
Fix(engine): Handle nil notifier to prevent panic

### DIFF
--- a/internal/alert/notifier.go
+++ b/internal/alert/notifier.go
@@ -72,3 +72,11 @@ func (n *DiscordNotifier) Close() error {
 	}
 	return nil
 }
+
+// NoOpNotifier is a notifier that does nothing.
+type NoOpNotifier struct{}
+
+// Send does nothing and returns nil. It's a no-op implementation.
+func (n *NoOpNotifier) Send(message string) error {
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,3 +284,9 @@ func LoadTradeConfigFromBytes(data []byte) (*TradeConfig, error) {
 	}
 	return &tradeCfg, nil
 }
+
+// SetTestConfig sets the global configuration to a specific config object.
+// This is intended for use in tests to inject a mock configuration.
+func SetTestConfig(cfg *Config) {
+	globalConfig.Store(cfg)
+}

--- a/internal/engine/execution_engine.go
+++ b/internal/engine/execution_engine.go
@@ -52,13 +52,21 @@ type LiveExecutionEngine struct {
 // NewLiveExecutionEngine creates a new LiveExecutionEngine.
 func NewLiveExecutionEngine(client *coincheck.Client, dbWriter dbwriter.DBWriter, notifier alert.Notifier) *LiveExecutionEngine {
 	cfg := config.GetConfig()
+
+	var activeNotifier alert.Notifier
+	if notifier == nil {
+		activeNotifier = &alert.NoOpNotifier{}
+	} else {
+		activeNotifier = notifier
+	}
+
 	engine := &LiveExecutionEngine{
 		exchangeClient: client,
 		dbWriter:       dbWriter,
 		position:       position.NewPosition(),
 		pnlCalculator:  pnl.NewCalculator(),
 		recentPnLs:     make([]float64, 0),
-		notifier:       notifier,
+		notifier:       activeNotifier,
 	}
 	// Initialize ratios from config
 	engine.currentRatios.OrderRatio = cfg.Trade.OrderRatio


### PR DESCRIPTION
A panic was occurring due to a nil pointer dereference when the DiscordNotifier was not initialized, but the `sendAlert` function was called.

This commit introduces a `NoOpNotifier` that does nothing. The `NewLiveExecutionEngine` now checks for a nil notifier and replaces it with the `NoOpNotifier` if necessary. This ensures that the engine always has a valid notifier, preventing panics.

Additionally, this commit fixes the tests by:
- Creating a `setupTest` helper to provide a valid default config.
- Updating tests to use the helper and not load configs from files.
- Ensuring the mock server handlers are correctly set up for all tests.