### PR TITLE
feat: Enhance order execution failure logging

### DIFF
--- a/internal/engine/execution_engine.go
+++ b/internal/engine/execution_engine.go
@@ -466,7 +466,10 @@ func (e *ReplayExecutionEngine) PlaceOrder(ctx context.Context, pair string, ord
 	}
 
 	if !executed {
-		return &coincheck.OrderResponse{Success: false, Error: "order not executed"}, nil
+		return &coincheck.OrderResponse{
+			Success: false,
+			Error:   fmt.Sprintf("order not executed: rate=%.2f, best_bid=%.2f, best_ask=%.2f", rate, bestBid, bestAsk),
+		}, nil
 	}
 
 	// Generate a deterministic transaction ID using the counter.


### PR DESCRIPTION
In simulation mode, when an order fails to execute, the log message was not providing enough context. This change enhances the error message to include the order rate, best bid, and best ask prices at the time of the failure. This will make it easier to debug why orders are not being filled in simulations.