### PR TITLE
fix: Add missing sync import

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -38,6 +38,7 @@ import (
 
 import (
 	"bufio"
+	"sync"
 )
 
 type flags struct {


### PR DESCRIPTION
The previous commit introduced the use of `sync.WaitGroup` but forgot to import the `sync` package, causing a build failure. This commit adds the missing import statement to `cmd/bot/main.go`.