### PR TITLE
fix: Correct optimizer loop logic to prevent premature exit

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -645,14 +645,17 @@ def main(run_once=False):
                 logging.info("Optimization run complete. Waiting for next job.")
 
             if run_once:
-                logging.info("Run once flag is set. Exiting main loop.")
-                break
+                if JOB_FILE.exists():
+                    # If the job file still exists, it means we didn't process it.
+                    # Loop again to attempt processing.
+                    time.sleep(1)
+                    continue
+                else:
+                    # If the job file is gone, it means we've processed it.
+                    logging.info("Job file processed and run_once is true. Exiting.")
+                    break
 
             time.sleep(10)
-            if run_once and not JOB_FILE.exists():
-                 # If we are running once and the job is gone, no need to keep sleeping
-                 logging.info("Job file processed and run_once is true. Exiting.")
-                 break
     finally:
         stop_go_sim_server()
 


### PR DESCRIPTION
The optimizer was exiting prematurely when the `--run-once` flag was used, because the exit condition was checked before the job file could be processed. This prevented the optimization from ever starting when triggered manually.

This commit modifies the main loop to ensure that when `run_once` is active, the script waits for the `optimization_job.json` file to be consumed before exiting. This allows the manual optimization trigger (`make optimize`) to function correctly.