### PR TITLE
fix: Correct Docker build context for timescaledb

### DIFF
--- a/docker/jules/Dockerfile.timescaledb
+++ b/docker/jules/Dockerfile.timescaledb
@@ -25,7 +25,7 @@ RUN set -e \
     && echo "shared_preload_libraries = 'timescaledb'" >> /usr/local/share/postgresql/postgresql.conf.sample
 
 # 4) 初期化スクリプト & ZIP シードデータ
-COPY 20_seed_stream.sh /docker-entrypoint-initdb.d/
+COPY docker/jules/20_seed_stream.sh /docker-entrypoint-initdb.d/
 COPY db/schema/jules/order_book_updates_jules.zip  /seed/order_book_updates_jules.zip
 RUN chmod +x /docker-entrypoint-initdb.d/20_seed_stream.sh
 


### PR DESCRIPTION
The Docker build for the `timescaledb` service was failing because the `COPY` instruction for `20_seed_stream.sh` was incorrect. The build context is the project root, so the path needed to be updated to `docker/timescaledb/20_seed_stream.sh`.

This commit corrects the path in `docker/timescaledb/Dockerfile.timescaledb` to ensure the build completes successfully.