### PR TITLE
fix: Remove CSV flag check in serve mode

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -80,8 +80,8 @@ func main() {
 	}
 	go watchConfigFiles(f.configPath, f.tradeConfigPath)
 
-	if (f.simulateMode || f.serveMode) && f.csvPath == "" {
-		logger.Fatal("CSV file path must be provided in simulation or serve mode using --csv flag")
+	if f.simulateMode && f.csvPath == "" {
+		logger.Fatal("CSV file path must be provided in simulation mode using --csv flag")
 	}
 
 	if !f.simulateMode && !f.serveMode {


### PR DESCRIPTION
The application was incorrectly requiring the `--csv` flag when starting in `--serve` mode, causing the optimizer to fail on startup.

The server mode is designed to receive CSV paths on a per-request basis, so the initial check is not necessary and has been removed for the serve mode.