### PR TITLE
fix: Correctly access study user_attrs in objective

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -354,7 +354,7 @@ def objective(trial, min_trades_for_pruning: int):
 
     # The CURRENT_SIM_CSV_PATH is now passed to run_simulation directly
     # The objective function itself doesn't need to know which CSV is being used.
-    summary = run_simulation(params, trial.storage.get_study_user_attrs(study_name='obi-scalp-optimization').get('current_csv_path'))
+    summary = run_simulation(params, trial.study.user_attrs.get('current_csv_path'))
 
 
     if summary is None:


### PR DESCRIPTION
The `objective` function was trying to access study-level user attributes using `trial.storage.get_study_user_attrs` with a `study_name` keyword argument, which is not a valid method.

This has been corrected to use `trial.study.user_attrs`, which is the correct and more direct way to access the user attributes of the study associated with the current trial.