### PR TITLE
fix: Resolve deadlock in simulation server by changing stdin reading

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -976,12 +976,22 @@ func runServerMode(ctx context.Context, f flags, sigs chan<- os.Signal) {
 
 	// Data is now loaded on-demand per request
 	marketDataCache := make(map[string][]coincheck.OrderBookData)
+	reader := bufio.NewReader(os.Stdin)
 
-	scanner := bufio.NewScanner(os.Stdin)
 	fmt.Println("READY")
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				logger.Info("Stdin closed, exiting server mode.")
+			} else {
+				logger.Fatalf("Error reading from stdin: %v", err)
+			}
+			break
+		}
+
+		line = strings.TrimSpace(line)
 		if line == "EXIT" {
 			logger.Info("Received EXIT command. Shutting down server mode.")
 			break


### PR DESCRIPTION
The simulation server was experiencing a deadlock, causing the optimization process to hang. This was likely due to the use of `bufio.Scanner` for reading from stdin, which can cause buffering issues when interacting with a Python process.

This commit changes the stdin reading mechanism in the Go server from `bufio.Scanner` to `bufio.Reader.ReadString('\n')`. This ensures that each line written by the Python process is immediately read and processed, preventing the deadlock. Error handling for `io.EOF` has also been added for graceful shutdown.