### PR TITLE
Fix: Prevent bot from hanging on WebSocket connection

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -607,11 +607,15 @@ func runMainLoop(ctx context.Context, f flags, dbWriter *dbwriter.Writer, sigs c
 		wsClient := coincheck.NewWebSocketClient(orderBookHandler, tradeHandler)
 		go func() {
 			logger.Info("Connecting to Coincheck WebSocket API...")
-			if err := wsClient.Connect(); err != nil {
+			if err := wsClient.Connect(ctx); err != nil {
 				logger.Warnf("WebSocket client exited with error: %v", err)
 				sigs <- syscall.SIGTERM
 			}
 		}()
+
+		// Wait for the WebSocket client to be ready before proceeding.
+		<-wsClient.Ready()
+		logger.Info("WebSocket client is ready.")
 	}
 }
 


### PR DESCRIPTION
The bot was getting stuck after subscribing to WebSocket channels due to the main goroutine not waiting for the WebSocket client to be ready.

This commit introduces a `ready` channel in the `WebSocketClient` to signal when subscriptions are complete. The main loop now waits on this channel before proceeding, ensuring that the bot is fully connected and subscribed before it starts its main operations.

Additionally, this commit fixes several failing tests in the execution engine by correcting test logic and moving risk management checks to occur before placing an order.