### PR TITLE
fix(optimizer): Change simulation manager logs to debug level

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -215,7 +215,7 @@ class SimulationManager:
             '--serve',
             f'--csv={self.csv_path}'
         ]
-        logging.info(f"Starting simulation server: {' '.join(command)}")
+        logging.debug(f"Starting simulation server: {' '.join(command)}")
         try:
             self.process = subprocess.Popen(
                 command,
@@ -231,7 +231,7 @@ class SimulationManager:
             if ready_line != "READY":
                 stderr = self.process.stderr.read()
                 raise RuntimeError(f"Simulation server failed to start. Expected 'READY', got '{ready_line}'. Stderr: {stderr}")
-            logging.info("Simulation server is READY.")
+            logging.debug("Simulation server is READY.")
         except (subprocess.SubprocessError, FileNotFoundError) as e:
             logging.error(f"Failed to start the simulation process: {e}")
             self.close()
@@ -290,12 +290,12 @@ class SimulationManager:
     def close(self):
         """Shuts down the simulation process."""
         if self.process and self.process.poll() is None:
-            logging.info("Closing simulation server...")
+            logging.debug("Closing simulation server...")
             try:
                 self.process.stdin.write("EXIT\n")
                 self.process.stdin.flush()
                 self.process.wait(timeout=5)
-                logging.info("Simulation server closed gracefully.")
+                logging.debug("Simulation server closed gracefully.")
             except (IOError, subprocess.TimeoutExpired) as e:
                 logging.warning(f"Failed to close gracefully, terminating: {e}")
                 self.process.terminate()


### PR DESCRIPTION
The logs related to the lifecycle of the `SimulationManager` (starting, ready, closing) were too verbose for the default INFO level, cluttering the optimization output.

This commit changes these specific log statements from `logging.info` to `logging.debug`. They will now only appear when the log level is explicitly set to DEBUG, resulting in a cleaner log output during normal runs.

This is a follow-up to the parallel execution refactoring.