### PR TITLE
docs(.env.sample): Add commented-out example for PostgreSQL STORAGE_URL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,7 +26,8 @@ GRAFANA_PASSWORD=admin
 REPORT_INTERVAL_MINUTES=1
 
 # Optimizer settings
-STORAGE_URL=sqlite:///optuna_study.db
+# STORAGE_URL=sqlite:///optuna_study.db
+# STORAGE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
 
 # Discord
 DISCORD_BOT_TOKEN=YOUR_DISCORD_BOT_TOKEN


### PR DESCRIPTION
To make it easier for you to switch to a PostgreSQL backend for Optuna, this commit adds an example `STORAGE_URL` to the `.env.sample` file.

- The existing SQLite `STORAGE_URL` is commented out.
- A new, commented-out line is added, showing how to construct the PostgreSQL connection string using other existing database-related environment variables (`DB_USER`, `DB_PASSWORD`, etc.).

This improves the project's documentation and simplifies the configuration process.