### PR TITLE
fix: Add cmaes dependency for CmaEsSampler

### DIFF
--- a/optimizer/requirements.txt
+++ b/optimizer/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary
 pandas
 scipy
 scikit-learn
+cmaes


### PR DESCRIPTION
The CmaEsSampler in Optuna requires the 'cmaes' library to be installed. This was missed in the previous commit and resulted in a ModuleNotFoundError.

This commit adds the missing dependency to requirements.txt.