### PR TITLE
fix: Suppress CmaEsSampler independent sampling warnings

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -453,7 +453,7 @@ def main(run_once=False):
 
             # --- Setup Study ---
             pruner = HyperbandPruner(min_resource=5, max_resource=100, reduction_factor=3)
-            sampler = optuna.samplers.CmaEsSampler()
+            sampler = optuna.samplers.CmaEsSampler(warn_independent_sampling=False)
             study = optuna.create_study(
                 study_name='obi-scalp-optimization',
                 storage=STORAGE_URL,


### PR DESCRIPTION
CmaEsSampler does not support categorical distributions and falls back to RandomSampler for them, issuing a warning. This is expected behavior for our use case.

This commit suppresses these warnings by setting `warn_independent_sampling=False` in the CmaEsSampler constructor to reduce log noise.