### PR TITLE
fix: Disable loading of previous studies

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -458,7 +458,7 @@ def main(run_once=False):
                 study_name='obi-scalp-optimization',
                 storage=STORAGE_URL,
                 direction='maximize',
-                load_if_exists=True,
+                load_if_exists=False,
                 pruner=pruner,
                 sampler=sampler
             )


### PR DESCRIPTION
The `load_if_exists` parameter for `optuna.create_study` was set to `True`, which could cause the optimizer to be biased by results from previous, unrelated optimization runs on different datasets.

This commit changes `load_if_exists` to `False` to ensure that every optimization job starts with a fresh, clean study, preventing any potential data leakage or bias from old results.