### PR TITLE
I've fixed the issue where the optimization run was failing. It was c…

### DIFF
--- a/optimizer/optimizer.py
+++ b/optimizer/optimizer.py
@@ -452,10 +452,12 @@ def main(run_once=False):
                 continue
 
             # --- Setup Study ---
+            study_name = f"obi-scalp-optimization-{int(time.time())}"
+            logging.info(f"Creating new Optuna study: {study_name}")
             pruner = HyperbandPruner(min_resource=5, max_resource=100, reduction_factor=3)
             sampler = optuna.samplers.CmaEsSampler(warn_independent_sampling=False)
             study = optuna.create_study(
-                study_name='obi-scalp-optimization',
+                study_name=study_name,
                 storage=STORAGE_URL,
                 direction='maximize',
                 load_if_exists=False,


### PR DESCRIPTION
…aused by a static study name, which led to a `DuplicatedStudyError`. To resolve this, I'm now generating a unique study name for each run by appending the current Unix timestamp. This ensures that every run is independent and starts with a new, clean study in the database.