### PR TITLE
feat: Filter for my trades in report generator

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -73,9 +73,20 @@ func (s *Service) AnalyzeTrades(trades []Trade) (Report, error) {
 		return Report{}, fmt.Errorf("no trades to analyze")
 	}
 
+	var myTrades []Trade
+	for _, t := range trades {
+		if t.IsMyTrade {
+			myTrades = append(myTrades, t)
+		}
+	}
+
+	if len(myTrades) == 0 {
+		return Report{}, fmt.Errorf("no trades to analyze")
+	}
+
 	var executedTrades []Trade
 	cancelledCount := 0
-	for _, t := range trades {
+	for _, t := range myTrades {
 		if t.IsCancelled {
 			cancelledCount++
 		} else {


### PR DESCRIPTION
The report generator now filters for trades where `IsMyTrade` is true, so that the Sharpe ratio and other metrics are calculated based only on your trades.