### PR TITLE
fix: declared and not used: orderSentTime

### DIFF
--- a/internal/engine/execution_engine.go
+++ b/internal/engine/execution_engine.go
@@ -125,7 +125,7 @@ func (e *LiveExecutionEngine) PlaceOrder(ctx context.Context, pair string, order
 	}
 
 	logger.Infof("[Live] Placing order: %+v", req)
-	orderResp, orderSentTime, err := e.exchangeClient.NewOrder(req)
+	orderResp, _, err := e.exchangeClient.NewOrder(req)
 	if err != nil {
 		logger.Warnf("[Live] Error placing order: %v, Response: %+v", err, orderResp)
 		return orderResp, err


### PR DESCRIPTION
`internal/engine/execution_engine.go`において、`orderSentTime`変数が宣言されているものの使用されていなかったため、ビルドエラーが発生していました。 この変数を `_` に変更し、意図的に無視することでエラーを解消しました。
Output:
fix: declared and not used: orderSentTime

In `internal/engine/execution_engine.go`, the `orderSentTime` variable was declared but not used, causing a build error. I've changed this variable to `_` to intentionally ignore it, which resolves the error.