### PR TITLE
feat: 複合シグナル生成ロジックを導入

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -465,7 +465,10 @@ func processSignalsAndExecute(ctx context.Context, obiCalculator *indicator.OBIC
 				if benchmarkService != nil {
 					benchmarkService.Tick(ctx, midPrice)
 				}
-				trades := webSocketClient.GetTrades()
+				var trades []coincheck.TradeData
+				if webSocketClient != nil {
+					trades = webSocketClient.GetTrades()
+				}
 				cvdTrades := convertTrades(trades)
 
 				signalEngine.UpdateMarketData(result.Timestamp, midPrice, result.BestBid, result.BestAsk, 1.0, 1.0, cvdTrades)


### PR DESCRIPTION
OBI, OFI, CVD, MicroPriceを組み合わせた複合シグナル生成ロジックを導入しました。

主な変更点:
- internal/signal/signal.go:
  - OBI, OFI, CVD, MicroPriceの各指標に重みを付けて複合スコアを計算し、シグナルを生成するようにEvaluate関数を修正。
  - SignalEngineに各指標の値を保持するフィールドと、計算に必要な設定値を追加。
- internal/config/config.go:
  - 複合シグナルの重みとしきい値を設定ファイルから読み込めるように、SignalConfigを拡張。
- pkg/cvd/cvd.go:
  - 状態を持つCVDCalculatorを導入し、時系列でのCVD計算を容易に。
- cmd/bot/main.go:
  - WebSocketから受信した取引データをCVD計算用にSignalEngineに渡すように修正。
  - シミュレーションモードでwebSocketClientがnilの場合にpanicする問題を修正。
- internal/indicator/trade_handler.go:
  - 不要になったため削除。
- テスト:
  - 既存のテストを新しいロジックに合わせて修正。
  - 複合シグナルが正しく計算・評価されることを確認する新しいテストケースを追加。