### PR TITLE
Fix signal calculation by passing correct best bid/ask sizes

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -471,7 +471,7 @@ func processSignalsAndExecute(ctx context.Context, obiCalculator *indicator.OBIC
 				}
 				cvdTrades := convertTrades(trades)
 
-				signalEngine.UpdateMarketData(result.Timestamp, midPrice, result.BestBid, result.BestAsk, 1.0, 1.0, cvdTrades)
+				signalEngine.UpdateMarketData(result.Timestamp, midPrice, result.BestBid, result.BestAsk, result.BestBidSize, result.BestAskSize, cvdTrades)
 
 				logger.Debugf("Evaluating OBI: %.4f, Long Threshold: %.4f, Short Threshold: %.4f",
 					result.OBI8, signalEngine.GetCurrentLongOBIThreshold(), signalEngine.GetCurrentShortOBIThreshold())

--- a/internal/indicator/orderbook.go
+++ b/internal/indicator/orderbook.go
@@ -12,11 +12,13 @@ import (
 
 // OBIResult holds the calculated OBI values for different levels and the timestamp.
 type OBIResult struct {
-	OBI8      float64   // Order Book Imbalance for top 8 levels
-	OBI16     float64   // Order Book Imbalance for top 16 levels
-	BestBid   float64   // Best bid price at the time of calculation
-	BestAsk   float64   // Best ask price at the time of calculation
-	Timestamp time.Time // Timestamp of the OBI calculation
+	OBI8        float64   // Order Book Imbalance for top 8 levels
+	OBI16       float64   // Order Book Imbalance for top 16 levels
+	BestBid     float64   // Best bid price at the time of calculation
+	BestAsk     float64   // Best ask price at the time of calculation
+	BestBidSize float64   // Best bid size at the time of calculation
+	BestAskSize float64   // Best ask size at the time of calculation
+	Timestamp   time.Time // Timestamp of the OBI calculation
 }
 
 // OrderBook represents a thread-safe order book.
@@ -177,6 +179,8 @@ func (ob *OrderBook) CalculateOBI(levels ...int) (OBIResult, bool) {
 
 	result.BestBid = bids[0].Rate
 	result.BestAsk = asks[0].Rate
+	result.BestBidSize = bids[0].Amount
+	result.BestAskSize = asks[0].Amount
 
 	maxLevel := 0
 	for _, l := range levels {

--- a/internal/indicator/orderbook_test.go
+++ b/internal/indicator/orderbook_test.go
@@ -73,10 +73,12 @@ func TestOrderBook_ApplySnapshotAndCalculateOBI(t *testing.T) {
 			),
 			levels: []int{8},
 			expected: indicator.OBIResult{
-				OBI8:      0,
-				BestBid:   100,
-				BestAsk:   101,
-				Timestamp: time.Unix(1678886403, 0),
+				OBI8:        0,
+				BestBid:     100,
+				BestAsk:     101,
+				BestBidSize: 10,
+				BestAskSize: 10,
+				Timestamp:   time.Unix(1678886403, 0),
 			},
 		},
 		{
@@ -95,11 +97,13 @@ func TestOrderBook_ApplySnapshotAndCalculateOBI(t *testing.T) {
 			),
 			levels: []int{8, 16},
 			expected: indicator.OBIResult{
-				OBI8:      14.0 / 34.0,
-				OBI16:     16.0 / 36.0,
-				BestBid:   100,
-				BestAsk:   101,
-				Timestamp: time.Unix(1678886404, 0),
+				OBI8:        14.0 / 34.0,
+				OBI16:       16.0 / 36.0,
+				BestBid:     100,
+				BestAsk:     101,
+				BestBidSize: 10,
+				BestAskSize: 2,
+				Timestamp:   time.Unix(1678886404, 0),
 			},
 		},
 		{
@@ -111,11 +115,13 @@ func TestOrderBook_ApplySnapshotAndCalculateOBI(t *testing.T) {
 			),
 			levels: []int{8, 16},
 			expected: indicator.OBIResult{
-				OBI8:      (10.0 - 5.0) / (10.0 + 5.0),
-				OBI16:     (10.0 - 5.0) / (10.0 + 5.0),
-				BestBid:   100,
-				BestAsk:   101,
-				Timestamp: time.Unix(1678886405, 0),
+				OBI8:        (10.0 - 5.0) / (10.0 + 5.0),
+				OBI16:       (10.0 - 5.0) / (10.0 + 5.0),
+				BestBid:     100,
+				BestAsk:     101,
+				BestBidSize: 10,
+				BestAskSize: 5,
+				Timestamp:   time.Unix(1678886405, 0),
 			},
 		},
 		{
@@ -127,11 +133,13 @@ func TestOrderBook_ApplySnapshotAndCalculateOBI(t *testing.T) {
 			),
 			levels: []int{8, 16},
 			expected: indicator.OBIResult{
-				OBI8:      (10.0 - 5.0) / (10.0 + 5.0),
-				OBI16:     (10.0 - 5.0) / (10.0 + 5.0),
-				BestBid:   100,
-				BestAsk:   101,
-				Timestamp: time.Unix(1678886406, 0),
+				OBI8:        (10.0 - 5.0) / (10.0 + 5.0),
+				OBI16:       (10.0 - 5.0) / (10.0 + 5.0),
+				BestBid:     100,
+				BestAsk:     101,
+				BestBidSize: 10,
+				BestAskSize: 5,
+				Timestamp:   time.Unix(1678886406, 0),
 			},
 		},
 	}
@@ -183,11 +191,13 @@ func TestOrderBook_ApplyUpdate(t *testing.T) {
 	ob.ApplyUpdate(updateData)
 
 	expected := indicator.OBIResult{
-		OBI8:      (20.0 - 15.0) / (20.0 + 15.0),
-		OBI16:     (20.0 - 15.0) / (20.0 + 15.0),
-		BestBid:   200,
-		BestAsk:   201,
-		Timestamp: time.Unix(1678886401, 0),
+		OBI8:        (20.0 - 15.0) / (20.0 + 15.0),
+		OBI16:       (20.0 - 15.0) / (20.0 + 15.0),
+		BestBid:     200,
+		BestAsk:     201,
+		BestBidSize: 20,
+		BestAskSize: 15,
+		Timestamp:   time.Unix(1678886401, 0),
 	}
 	actual, ok := ob.CalculateOBI(8, 16)
 	if !ok {


### PR DESCRIPTION
The signal calculation was flawed because it was using hardcoded values (1.0) for best bid and ask sizes when updating the market data in the signal engine. This resulted in an incorrect microprice calculation, which in turn affected the composite score used for signal generation.

This commit addresses the issue by:

1.  Extending the `OBIResult` struct to include `BestBidSize` and `BestAskSize`.
2.  Populating these new fields in the `CalculateOBI` function.
3.  Passing the correct `BestBidSize` and `BestAskSize` from the `OBIResult` to the `signalEngine.UpdateMarketData` function in `main.go`.
4.  Fixing the failing unit tests in `internal/engine` and `internal/indicator` that were affected by these changes.

With these changes, the microprice and the overall composite score will be calculated correctly, leading to more accurate trading signals.