### PR TITLE
Fix(signal): Improve signal generation robustness

### DIFF
--- a/internal/indicator/orderbook.go
+++ b/internal/indicator/orderbook.go
@@ -171,12 +171,16 @@ func (ob *OrderBook) CalculateOBI(levels ...int) (OBIResult, bool) {
 		return asks[i].Rate < asks[j].Rate
 	})
 
-	if len(bids) == 0 || len(asks) == 0 {
-		return OBIResult{Timestamp: ob.Time}, false
+	if len(bids) > 0 {
+		result.BestBid = bids[0].Rate
+	}
+	if len(asks) > 0 {
+		result.BestAsk = asks[0].Rate
 	}
 
-	result.BestBid = bids[0].Rate
-	result.BestAsk = asks[0].Rate
+	if len(bids) == 0 || len(asks) == 0 {
+		return result, false
+	}
 
 	maxLevel := 0
 	for _, l := range levels {

--- a/internal/indicator/orderbook_test.go
+++ b/internal/indicator/orderbook_test.go
@@ -43,6 +43,7 @@ func TestOrderBook_ApplySnapshotAndCalculateOBI(t *testing.T) {
 			),
 			levels: []int{8, 16},
 			expected: indicator.OBIResult{
+				BestBid:   100,
 				Timestamp: time.Unix(1678886401, 0),
 			},
 		},
@@ -55,6 +56,7 @@ func TestOrderBook_ApplySnapshotAndCalculateOBI(t *testing.T) {
 			),
 			levels: []int{8, 16},
 			expected: indicator.OBIResult{
+				BestAsk:   101,
 				Timestamp: time.Unix(1678886402, 0),
 			},
 		},


### PR DESCRIPTION
- Modified `OBICalculator` to send partial results even when OBI calculation fails (e.g., one side of the order book is empty). This allows other indicators (OFI, CVD, MicroPrice) to be used for signal evaluation, preventing missed trading opportunities.
- Updated `OrderBook.CalculateOBI` to return `BestBid` and `BestAsk` values even if one side of the book is empty.
- Adjusted unit tests to match the new behavior.