### PR TITLE
fix: Increase OBICalculator channel buffer size

### DIFF
--- a/internal/indicator/obi.go
+++ b/internal/indicator/obi.go
@@ -28,7 +28,7 @@ func NewOBICalculator(ob *OrderBook, interval time.Duration) *OBICalculator {
 		orderBook: ob,
 		interval:  interval,
 		done:      make(chan struct{}),
-		output:    make(chan OBIResult, 1), // Buffered channel to avoid blocking
+		output:    make(chan OBIResult, 100), // Buffered channel to avoid blocking
 	}
 }
 


### PR DESCRIPTION
Increases the buffer size of the output channel in the OBICalculator from 1 to 100.

This prevents the channel from becoming full and dropping data when the consumer is temporarily slow, which was causing 'OBICalculator output channel is full, skipping send' warnings.