### PR TITLE
fix(optimizer): 最終的なYAMLアンマーシャルエラーを修正

### DIFF
--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -226,9 +226,14 @@ def _get_oos_fail_reason(oos_summary: dict) -> str:
 def _save_best_parameters(params: dict):
     """Renders and saves the final trade configuration file."""
     try:
+        # Ensure boolean parameters are correctly formatted as strings for the final config.
+        processed_params = {
+            k: str(v).lower() if isinstance(v, bool) else v
+            for k, v in params.items()
+        }
         with open(config.CONFIG_TEMPLATE_PATH, 'r') as f:
             template = Template(f.read())
-        config_str = template.render(params)
+        config_str = template.render(processed_params)
         with open(config.BEST_CONFIG_OUTPUT_PATH, 'w') as f:
             f.write(config_str)
         logging.info(f"Successfully updated trade config: {config.BEST_CONFIG_OUTPUT_PATH}")


### PR DESCRIPTION
OOS検証が成功した後に、最終的な`trade_config.yaml`を保存する際に、依然としてYAMLのアンマーシャルエラーが発生していた問題を修正しました。

主な変更点:
- `optimizer/study.py`の`_save_best_parameters`関数に、パラメータの真偽値を文字列に変換する処理を追加しました。
- これにより、OOS検証をパスしたパラメータセットが最終的な設定ファイルとして保存される際に、Jinja2が`True`/`False`を`1`/`0`としてレンダリングする問題を防ぎ、Goシミュレーションが期待する`true`/`false`の形式で出力されるようになります。
- この修正は、`_perform_oos_validation`関数内で行った修正と合わせて、パラメータのライフサイクル全体で真偽値の形式を保証するものです。