### PR TITLE
fix(config): YAMLのアンマーシャルエラーを修正 (FlexBool)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,10 +49,10 @@ type Config struct {
 
 // AdaptiveSizingConfig holds settings for the adaptive position sizing feature.
 type AdaptiveSizingConfig struct {
-	Enabled       bool    `yaml:"enabled"`
-	NumTrades     int     `yaml:"num_trades"`
-	ReductionStep float64 `yaml:"reduction_step"`
-	MinRatio      float64 `yaml:"min_ratio"`
+	Enabled       FlexBool `yaml:"enabled"`
+	NumTrades     int      `yaml:"num_trades"`
+	ReductionStep float64  `yaml:"reduction_step"`
+	MinRatio      float64  `yaml:"min_ratio"`
 }
 
 // AlertConfig holds alert settings.
@@ -62,9 +62,9 @@ type AlertConfig struct {
 
 // DiscordConfig holds Discord notification settings.
 type DiscordConfig struct {
-	Enabled  bool   `yaml:"enabled"`
-	BotToken string `yaml:"bot_token"`
-	UserID   string `yaml:"user_id"`
+	Enabled  FlexBool `yaml:"enabled"`
+	BotToken string   `yaml:"bot_token"`
+	UserID   string   `yaml:"user_id"`
 }
 
 // RiskConfig holds risk management settings.
@@ -87,9 +87,9 @@ type SignalConfig struct {
 
 // SlopeFilterConfig holds settings for the OBI slope filter.
 type SlopeFilterConfig struct {
-	Enabled   bool    `yaml:"enabled"`
-	Period    int     `yaml:"period"`
-	Threshold float64 `yaml:"threshold"`
+	Enabled   FlexBool `yaml:"enabled"`
+	Period    int      `yaml:"period"`
+	Threshold float64  `yaml:"threshold"`
 }
 
 // OrderConfig holds configuration for the execution engine.
@@ -100,12 +100,12 @@ type OrderConfig struct {
 
 // TwapConfig holds configuration for the TWAP execution strategy.
 type TwapConfig struct {
-	Enabled             bool    `yaml:"enabled"`
-	MaxOrderSizeBtc     float64 `yaml:"max_order_size_btc"`
-	IntervalSeconds     int     `yaml:"interval_seconds"`
-	PartialExitEnabled  bool    `yaml:"partial_exit_enabled"`
-	ProfitThreshold     float64 `yaml:"profit_threshold"`
-	ExitRatio           float64 `yaml:"exit_ratio"`
+	Enabled             FlexBool `yaml:"enabled"`
+	MaxOrderSizeBtc     float64  `yaml:"max_order_size_btc"`
+	IntervalSeconds     int      `yaml:"interval_seconds"`
+	PartialExitEnabled  FlexBool `yaml:"partial_exit_enabled"`
+	ProfitThreshold     float64  `yaml:"profit_threshold"`
+	ExitRatio           float64  `yaml:"exit_ratio"`
 }
 
 // ReplayConfig holds configuration for the replay mode.
@@ -132,9 +132,9 @@ type DatabaseConfig struct {
 
 // DBWriterConfig holds configuration for the TimescaleDB writer service.
 type DBWriterConfig struct {
-	BatchSize            int  `yaml:"batch_size"`
-	WriteIntervalSeconds int  `yaml:"write_interval_seconds"`
-	EnableAsync          bool `yaml:"enable_async"`
+	BatchSize            int      `yaml:"batch_size"`
+	WriteIntervalSeconds int      `yaml:"write_interval_seconds"`
+	EnableAsync          FlexBool `yaml:"enable_async"`
 }
 
 // StrategyConf holds configuration for long/short strategies.
@@ -152,8 +152,8 @@ type VolConf struct {
 
 // DynamicOBIConf holds configuration for dynamic OBI threshold adjustments.
 type DynamicOBIConf struct {
-	Enabled          bool    `yaml:"enabled"`
-	VolatilityFactor float64 `yaml:"volatility_factor"`
+	Enabled          FlexBool `yaml:"enabled"`
+	VolatilityFactor float64  `yaml:"volatility_factor"`
 	MinThresholdFactor float64 `yaml:"min_threshold_factor"`
 	MaxThresholdFactor float64 `yaml:"max_threshold_factor"`
 }

--- a/internal/config/custom_types.go
+++ b/internal/config/custom_types.go
@@ -1,0 +1,45 @@
+// Package config handles application configuration.
+package config
+
+import (
+	"fmt"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FlexBool is a boolean type that can be unmarshalled from a boolean, a string, or a number.
+type FlexBool bool
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for FlexBool.
+func (fb *FlexBool) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Tag {
+	case "!!bool":
+		var b bool
+		if err := value.Decode(&b); err != nil {
+			return err
+		}
+		*fb = FlexBool(b)
+	case "!!str":
+		b, err := strconv.ParseBool(value.Value)
+		if err != nil {
+			return fmt.Errorf("cannot unmarshal string %q into FlexBool", value.Value)
+		}
+		*fb = FlexBool(b)
+	case "!!int":
+		i, err := strconv.Atoi(value.Value)
+		if err != nil {
+			return err
+		}
+		*fb = FlexBool(i != 0)
+	case "!!float":
+		f, err := strconv.ParseFloat(value.Value, 64)
+		if err != nil {
+			return err
+		}
+		*fb = FlexBool(f != 0)
+	default:
+		return fmt.Errorf("cannot unmarshal %s into FlexBool", value.Tag)
+	}
+	return nil
+}


### PR DESCRIPTION
Pythonのオプティマイザが生成するパラメータ（`0.0`や`1.0`）をGoの`bool`型にアンマーシャルできずに繰り返し発生していた問題を、Go側で吸収する形で修正しました。

主な変更点:
- `internal/config/custom_types.go`を新設し、`FlexBool`というカスタム型を定義しました。
- `FlexBool`型は`yaml.Unmarshaler`インターフェースを実装しており、`bool`値、文字列の`"true"`/`"false"`、さらには数値の`0`/`1`や`0.0`/`1.0`からも真偽値を正しく解釈できます。
- `internal/config/config.go`内のすべての`bool`型フィールドを、この新しい`FlexBool`型に置き換えました。

このアプローチにより、Python側でどのような形式の真偽値が生成されても、Go側で柔軟に受け取れるようになり、アンマーシャルエラーの根本的な原因を解決します。