### PR TITLE
fix(engine): FlexBoolの型ミスマッチを修正

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -514,7 +514,7 @@ func processSignalsAndExecute(ctx context.Context, obiCalculator *indicator.OBIC
 						// Only proceed if the order amount is above the minimum
 						if orderAmount >= 0.001 {
 							logger.Debugf("Executing trade for signal: %s. %s", tradingSignal.Type.String(), orderLogMsg)
-							if currentCfg.Trade.Twap.Enabled && orderAmount > currentCfg.Trade.Twap.MaxOrderSizeBtc {
+							if bool(currentCfg.Trade.Twap.Enabled) && orderAmount > currentCfg.Trade.Twap.MaxOrderSizeBtc {
 								logger.Debugf("Order amount %.8f exceeds max size %.8f. Executing with TWAP.", orderAmount, currentCfg.Trade.Twap.MaxOrderSizeBtc)
 								go executeTwapOrder(ctx, execEngine, currentCfg.Trade.Pair, orderType, finalPrice, orderAmount)
 							} else {
@@ -1357,7 +1357,7 @@ func orderMonitor(ctx context.Context, execEngine engine.ExecutionEngine, client
 // positionMonitor periodically checks the current position for potential partial profit taking.
 func positionMonitor(ctx context.Context, execEngine engine.ExecutionEngine, orderBook *indicator.OrderBook) {
 	cfg := config.GetConfig()
-	if !cfg.Trade.Twap.PartialExitEnabled {
+	if !bool(cfg.Trade.Twap.PartialExitEnabled) {
 		logger.Info("Position monitor (partial exit) is disabled.")
 		return
 	}

--- a/internal/alert/notifier.go
+++ b/internal/alert/notifier.go
@@ -29,7 +29,7 @@ type DiscordNotifier struct {
 // NewDiscordNotifier creates a new DiscordNotifier.
 // It requires a valid bot token and a user ID to send messages to.
 func NewDiscordNotifier(cfg config.DiscordConfig) (*DiscordNotifier, error) {
-	if !cfg.Enabled {
+	if !bool(cfg.Enabled) {
 		return nil, nil
 	}
 

--- a/internal/alert/notifier_test.go
+++ b/internal/alert/notifier_test.go
@@ -42,7 +42,7 @@ func (m *MockDiscordSession) Close() error {
 func TestNewDiscordNotifier_Unit(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := config.DiscordConfig{
-			Enabled:  true,
+			Enabled:  config.FlexBool(true),
 			BotToken: "fake-token",
 			UserID:   "fake-user-id",
 		}
@@ -58,7 +58,7 @@ func TestNewDiscordNotifier_Unit(t *testing.T) {
 
 	t.Run("disabled", func(t *testing.T) {
 		cfg := config.DiscordConfig{
-			Enabled:  false,
+			Enabled:  config.FlexBool(false),
 			BotToken: "fake-token",
 			UserID:   "fake-user-id",
 		}
@@ -68,7 +68,7 @@ func TestNewDiscordNotifier_Unit(t *testing.T) {
 	})
 
 	t.Run("missing bot token", func(t *testing.T) {
-		cfg := config.DiscordConfig{Enabled: true, UserID: "fake-user-id"}
+		cfg := config.DiscordConfig{Enabled: config.FlexBool(true), UserID: "fake-user-id"}
 		notifier, err := NewDiscordNotifier(cfg)
 		assert.Error(t, err)
 		assert.Nil(t, notifier)
@@ -76,7 +76,7 @@ func TestNewDiscordNotifier_Unit(t *testing.T) {
 	})
 
 	t.Run("missing user id", func(t *testing.T) {
-		cfg := config.DiscordConfig{Enabled: true, BotToken: "fake-token"}
+		cfg := config.DiscordConfig{Enabled: config.FlexBool(true), BotToken: "fake-token"}
 		notifier, err := NewDiscordNotifier(cfg)
 		assert.Error(t, err)
 		assert.Nil(t, notifier)

--- a/internal/engine/execution_engine.go
+++ b/internal/engine/execution_engine.go
@@ -389,7 +389,7 @@ func (e *LiveExecutionEngine) CheckAndTriggerPartialExit(currentMidPrice float64
 
 	cfg := config.GetConfig()
 
-	if e.isExitingPartially || !cfg.Trade.Twap.PartialExitEnabled {
+	if e.isExitingPartially || !bool(cfg.Trade.Twap.PartialExitEnabled) {
 		return nil
 	}
 

--- a/internal/engine/execution_engine_test.go
+++ b/internal/engine/execution_engine_test.go
@@ -41,13 +41,13 @@ func setupTest(t *testing.T) (*httptest.Server, *config.Config) {
 				MaxPositionRatio:   0.5,
 			},
 			AdaptivePositionSizing: config.AdaptiveSizingConfig{
-				Enabled:       false,
+				Enabled:       config.FlexBool(false),
 				NumTrades:     5,
 				ReductionStep: 0.8,
 				MinRatio:      0.5,
 			},
 			Twap: config.TwapConfig{
-				PartialExitEnabled: false,
+				PartialExitEnabled: config.FlexBool(false),
 			},
 		},
 		EnableTrade: true,
@@ -496,7 +496,7 @@ func TestExecutionEngine_AdaptivePositionSizing(t *testing.T) {
 	cfg.Trade.OrderRatio = 0.2
 	cfg.Trade.LotMaxRatio = 0.2
 	cfg.Trade.AdaptivePositionSizing = config.AdaptiveSizingConfig{
-		Enabled:       true,
+		Enabled:       config.FlexBool(true),
 		NumTrades:     5,
 		ReductionStep: 0.8,
 		MinRatio:      0.5,
@@ -608,7 +608,7 @@ func TestLiveExecutionEngine_CheckAndTriggerPartialExit(t *testing.T) {
 	mockServer, cfg := setupTest(t)
 	defer mockServer.Close()
 	cfg.Trade.Twap = config.TwapConfig{
-		PartialExitEnabled: true,
+		PartialExitEnabled: config.FlexBool(true),
 		ProfitThreshold:    1.0, // 1%
 		ExitRatio:          0.5, // 50%
 	}
@@ -659,7 +659,7 @@ func TestLiveExecutionEngine_CheckAndTriggerPartialExit(t *testing.T) {
 
 	t.Run("Disabled in config", func(t *testing.T) {
 		originalValue := cfg.Trade.Twap.PartialExitEnabled
-		cfg.Trade.Twap.PartialExitEnabled = false
+		cfg.Trade.Twap.PartialExitEnabled = config.FlexBool(false)
 		defer func() { cfg.Trade.Twap.PartialExitEnabled = originalValue }()
 
 		engine := NewLiveExecutionEngine(nil, nil, nil)

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -177,7 +177,7 @@ func (e *SignalEngine) UpdateMarketData(currentTime time.Time, currentMidPrice, 
 	}
 
 	// Update Volatility and dynamic OBI thresholds
-	if e.config.DynamicOBIConf.Enabled {
+	if bool(e.config.DynamicOBIConf.Enabled) {
 		_, stdDev := e.volatilityCalc.Update(e.currentMidPrice)
 		longAdjustment := e.config.DynamicOBIConf.VolatilityFactor * stdDev
 		adjustedLongThreshold := e.config.LongOBIBaseThreshold * (1 + longAdjustment)
@@ -213,7 +213,7 @@ func (e *SignalEngine) Evaluate(currentTime time.Time, obiValue float64) *Tradin
 	}
 
 	// Update score history for slope filter
-	if e.slopeFilterConfig.Enabled {
+	if bool(e.slopeFilterConfig.Enabled) {
 		e.obiHistory = append(e.obiHistory, obiValue)
 		if len(e.obiHistory) > e.slopeFilterConfig.Period {
 			e.obiHistory = e.obiHistory[1:]
@@ -239,7 +239,7 @@ func (e *SignalEngine) Evaluate(currentTime time.Time, obiValue float64) *Tradin
 	}
 
 	// Apply slope filter
-	if e.slopeFilterConfig.Enabled && rawSignal != SignalNone {
+	if bool(e.slopeFilterConfig.Enabled) && rawSignal != SignalNone {
 		slope := e.calculateOBISlope()
 		if rawSignal == SignalLong && slope < e.slopeFilterConfig.Threshold {
 			rawSignal = SignalNone


### PR DESCRIPTION
`config.FlexBool`を導入したことによる、Goコード内の型ミスマッチエラーを修正しました。

主な変更点:
- `internal/engine/execution_engine.go`、`cmd/bot/main.go`、`internal/alert/notifier.go`、`internal/signal/signal.go`内の、`FlexBool`型が`bool`として直接使用されていた箇所を、`bool(flexBoolValue)`のように明示的にキャストするように修正しました。
- `_test.go`ファイル内の、`FlexBool`型フィールドに`bool`リテラルを直接代入していた箇所を、`config.FlexBool(true)`のように正しくキャストして代入するように修正しました。

これにより、`FlexBool`の導入によって発生したコンパイルエラーが解消されます。