### PR TITLE
`optimizer`: OOS検証が機能しない問題を修正

### DIFF
--- a/optimizer/data.py
+++ b/optimizer/data.py
@@ -132,32 +132,20 @@ def _split_data_by_timestamp(full_dataset_path: Path, total_hours: float, oos_ho
 def _parse_timestamp(ts_str: str) -> datetime:
     """
     Parses a timestamp string into a timezone-aware datetime object.
-    Handles multiple common timestamp formats, including ISO 8601 variants.
+    Handles multiple common timestamp formats, including the one from Go's export script.
     """
-    # Pre-process for common non-standard formats
-    if ts_str.endswith('+00'):
-        # Handles '...-01-01 12:34:56.123+00' -> '...-01-01 12:34:56.123+00:00'
-        # which is required by fromisoformat
-        ts_str = ts_str + ':00'
-    elif ts_str.endswith('Z'):
-        ts_str = ts_str[:-1] + '+00:00'
+    # The Go export script produces timestamps like "2024-07-29 12:34:56.123456-07".
+    # datetime.fromisoformat can handle this if we add a colon to the timezone offset.
+    if len(ts_str) > 6 and (ts_str[-3] == '+' or ts_str[-3] == '-') and ':' not in ts_str[-6:]:
+        # Convert "YYYY-MM-DD HH:MM:SS.ffffff-07" to "YYYY-MM-DD HH:MM:SS.ffffff-07:00"
+        ts_str = ts_str[:-3] + ts_str[-3:] + ':00'
 
-    # Replace space with T for ISO 8601 compatibility
-    if ' ' in ts_str and 'T' not in ts_str:
+    # Replace space with 'T' for full ISO 8601 compatibility, which fromisoformat prefers.
+    if ' ' in ts_str:
         ts_str = ts_str.replace(' ', 'T', 1)
 
     try:
-        # datetime.fromisoformat is more robust for ISO 8601 formats
         return datetime.fromisoformat(ts_str)
     except ValueError:
-        # Fallback to strptime for other formats if fromisoformat fails
-        for fmt in (
-            '%Y-%m-%dT%H:%M:%S.%f%z',
-            '%Y-%m-%dT%H:%M:%S%z',
-        ):
-            try:
-                return datetime.strptime(ts_str, fmt)
-            except ValueError:
-                continue
-
-    raise ValueError(f"Could not parse timestamp: '{ts_str}' with any known format.")
+        # If fromisoformat fails, raise an error as we've already pre-processed for it.
+        raise ValueError(f"Could not parse timestamp: '{ts_str}' after pre-processing.")


### PR DESCRIPTION
OOS(Out-of-Sample)検証において、PF, SR, Tradesが常に0となってしまい、正常に検証が行えない問題を修正しました。

原因は、Go言語のデータエクスポート機能が出力するタイムスタンプ形式（例: `2024-07-29 12:34:56.123456-07`）を、Pythonのタイムスタンプ解析関数 `_parse_timestamp` が正しく処理できていなかったことでした。

これにより、時間ベースでのデータ分割に失敗し、常に行数ベースでの分割にフォールバックしていたため、OOSデータセットに取引シミュレーション可能なデータが含まれない状態となっていました。

`optimizer/data.py` の `_parse_timestamp` 関数を、Goが出力するタイムスタンプ形式を正しくISO 8601形式に変換するように修正し、時間ベースのデータ分割が常に正しく行われるようにしました。