### PR TITLE
fix: Nonce生成ロジックをインクリメンタルな方式に変更

### DIFF
--- a/internal/exchange/coincheck/order.go
+++ b/internal/exchange/coincheck/order.go
@@ -62,11 +62,10 @@ func (c *Client) newRequest(method, endpoint string, body io.Reader) (*http.Requ
 	}
 
 	c.mu.Lock()
-	nonceVal := time.Now().UnixNano()
-	if nonceVal <= c.lastNonce {
-		nonceVal = c.lastNonce + 1
-	}
-	c.lastNonce = nonceVal
+	// Always increment the last nonce; using time.Now().UnixNano() can be problematic
+	// in high-frequency trading scenarios or if the system clock is adjusted.
+	c.lastNonce++
+	nonceVal := c.lastNonce
 	c.mu.Unlock()
 
 	nonce := strconv.FormatInt(nonceVal, 10)


### PR DESCRIPTION
Coincheck APIへのリクエスト時に使用するNonceの生成ロジックを、`time.Now().UnixNano()`に依存しない、単純なインクリメント方式に変更しました。

これにより、高頻度のAPIリクエストやシステム時刻の変更が発生した場合でも、Nonceの重複を防ぎ、`Nonce must be incremented`エラーの発生を回避します。