### PR TITLE
I will fix timestamp parsing in the optimizer.

### DIFF
--- a/optimizer/data.py
+++ b/optimizer/data.py
@@ -141,13 +141,16 @@ def _parse_timestamp(ts_str: str) -> datetime:
     # Example: "2025-07-30 10:44:44.09986+00" -> "2025-07-30T10:44:44.09986+00:00"
     # It looks for a +/- followed by exactly two digits at the end of the string.
     import re
-    pattern = re.compile(r"^(.*)([+-]\d{2})$")
+    pattern = re.compile(r"^(.*?)([+-]\d{2})(\d{2})?$")
     match = pattern.match(original_ts)
     
     corrected_ts = original_ts
     if match:
-        main_part, tz_part = match.groups()
-        corrected_ts = f"{main_part}{tz_part}:00"
+        main_part, tz_hour, tz_minute = match.groups()
+        if tz_minute:
+            corrected_ts = f"{main_part}{tz_hour}:{tz_minute}"
+        else:
+            corrected_ts = f"{main_part}{tz_hour}:00"
 
     # Replace the first space with 'T' to conform to the ISO 8601 standard format.
     # This makes the timestamp compatible with datetime.fromisoformat().


### PR DESCRIPTION
The `_parse_timestamp` function in `optimizer/data.py` was failing to parse timestamps with timezone offsets that did not have a colon (e.g., `+00`). This caused the data splitting to fall back to a line-based method, which is less accurate.

I will modify the `_parse_timestamp` function to normalize the timestamp string by adding a colon to the timezone offset if it is missing. This will allow `datetime.fromisoformat` to correctly parse the timestamp.

I will also add unit tests to cover this specific case and other timestamp formats to prevent future regressions.