### PR TITLE
Fix report-generator startup issue

### DIFF
--- a/cmd/report/Dockerfile
+++ b/cmd/report/Dockerfile
@@ -20,10 +20,10 @@ RUN CGO_ENABLED=0 go build -o /app/report-generator ./cmd/report
 # --- Final Stage ---
 FROM alpine:3.19
 
-WORKDIR /app
+WORKDIR /
 
 # Copy the binary from the builder stage
-COPY --from=builder /app/report-generator .
+COPY --from=builder /app/report-generator /app/report-generator
 
 # Command to run the application
-CMD ["./report-generator"]
+CMD ["/app/report-generator"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,8 +93,6 @@ services:
       context: .
       dockerfile: cmd/report/Dockerfile
     container_name: obi-scalp-report-generator
-    env_file:
-      - .env
     environment:
       - DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@timescaledb:${DB_PORT}/${DB_NAME}?sslmode=disable
       - REPORT_INTERVAL_MINUTES=1


### PR DESCRIPTION
The report-generator service was failing to start due to a combination of issues in the Dockerfile and docker-compose.yml.

This commit addresses the following:

- In `cmd/report/Dockerfile`:
  - Corrected the `COPY` destination for the built binary to use an absolute path.
  - Adjusted `WORKDIR` and `CMD` to ensure the binary is executed from the correct location.
- In `docker-compose.yml`:
  - Removed the `env_file` directive for the report-generator service to avoid path resolution issues. The necessary environment variables are already defined.