### PR TITLE
fix: PFが異常値になる問題を修正

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1160,12 +1160,9 @@ func getSimulationSummaryMap(replayEngine *engine.ReplayExecutionEngine) map[str
 	if totalLossAmount != 0 {
 		profitFactor = math.Abs(totalWinAmount / totalLossAmount)
 	} else if totalWinAmount > 0 {
-		profitFactor = totalWinAmount // Use total profit as a fallback, will be capped later
-	}
-	// PFが極端に大きい場合（損失がゼロに近い場合）に値を丸める
-	const maxProfitFactor = 1000.0
-	if profitFactor > maxProfitFactor {
-		profitFactor = maxProfitFactor
+		// If there are profits but no losses, this can skew optimization.
+		// Setting PF to 0.0 effectively penalizes such scenarios.
+		profitFactor = 0.0
 	}
 	summary["ProfitFactor"] = profitFactor
 


### PR DESCRIPTION
optimizerにおいて、損失がゼロの場合にProfit Factorが1000.0に振り切れてしまう問題を修正しました。 損失がゼロの試行はリスク評価が困難であり、最適化の妨げとなるため、Profit Factorが0.0になるように変更しました。 これにより、より安定したパラメータチューニングが期待できます。