### PR TITLE
fix(report-generator): 約定済み取引がない場合に空のレポートが生成される問題を修正

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -85,12 +85,9 @@ func (s *Service) AnalyzeTrades(trades []Trade) (Report, error) {
 	}
 
 	if len(executedTrades) == 0 {
-		return Report{
-			StartDate:       trades[0].Time,
-			EndDate:         trades[len(trades)-1].Time,
-			CancelledTrades: cancelledCount,
-			TotalTrades:     0,
-		}, nil
+		// If there are no executed trades, we shouldn't generate a report.
+		// Return an error to prevent a "zero trade" report from being saved.
+		return Report{}, fmt.Errorf("no executed trades to analyze, only %d cancelled trades found", cancelledCount)
 	}
 
 	var buys, sells []Trade


### PR DESCRIPTION
pnl_reportsテーブルにおいて、total_tradesが0のレコードと0以外のレコードが1分ごとに交互に記録される問題がありました。

原因は、report-generatorサービスが、新しい取引の中に約定済みのもの(executed trades)が1件もなく、キャンセル済みの取引のみが存在する場合に、total_tradesが0のレポートを生成・保存していたためでした。新しい取引が全くない場合はレポートが生成されないため、結果として古いデータと0件のデータが交互に表示される状態となっていました。

修正として、約定済みの取引が0件の場合はレポートを生成せず、エラーを返すように`AnalyzeTrades`関数のロジックを変更しました。これにより、不要な「0件レポート」の挿入を防ぎ、データが安定します。