### PR TITLE
feat(optimizer): Implement rolling-study warm-start for Optuna

### DIFF
--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -49,6 +49,11 @@ def run_optimization_job(job: dict):
 
         # --- 2. Setup and Run Optuna Study ---
         optuna_study = study.create_study()
+
+        # Perform warm-start using recent trials from previous studies
+        recent_days = job.get('recent_days_warm_start', 10) # Default to 10 days
+        study.warm_start_with_recent_trials(optuna_study, recent_days)
+
         study.run_optimization(optuna_study, is_csv_path, n_trials)
 
         # --- 3. Analyze Results and Perform OOS Validation ---

--- a/optimizer/run_test.py
+++ b/optimizer/run_test.py
@@ -62,9 +62,11 @@ def ensure_dummy_trade_config():
 
 def run():
     """Runs the full optimization process for testing."""
-    # Set DB_HOST to localhost for direct connection from the script
-    os.environ['DB_HOST'] = 'localhost'
-    print("Set DB_HOST to localhost for testing.")
+    # For in-container testing where the container is not on the same docker network,
+    # use host.docker.internal to connect to the host machine where docker exposes the port.
+    db_host = os.environ.get('DB_HOST', 'host.docker.internal')
+    os.environ['DB_HOST'] = db_host
+    print(f"Set DB_HOST to {db_host} for testing.")
 
     # Ensure .env file exists and load it
     env_path = APP_ROOT / '.env'
@@ -84,11 +86,11 @@ def run():
                 key, value = line.strip().split('=', 1)
                 os.environ[key] = value
 
-    # Construct DATABASE_URL, overriding DB_HOST to localhost
+    # Construct DATABASE_URL, using the resolved DB_HOST
     db_user = os.getenv('DB_USER')
     db_password = os.getenv('DB_PASSWORD')
     db_name = os.getenv('DB_NAME')
-    db_host = 'localhost' # Force localhost for test script
+    # db_host is already set from os.environ['DB_HOST']
     db_port = os.getenv('DB_PORT')
     if all([db_user, db_password, db_name, db_host, db_port]):
         os.environ['DATABASE_URL'] = f"postgres://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}?sslmode=disable"


### PR DESCRIPTION
I've implemented a rolling-study warm-start mechanism for the Optuna optimizer to improve convergence speed while mitigating bias from stale, historical data.

Key changes:
- I changed the Optuna sampler in `study.py` from `CmaEsSampler` to `TPESampler` to leverage its `consider_prior` functionality.
- I added a new function, `warm_start_with_recent_trials`, to `study.py`. This function loads the most recent previous study, filters its trials to include only those from a recent period (e.g., the last 10 days), and injects them into the current study.
- I updated the main optimization job in `main.py` to call this new function after creating a study, effectively warm-starting the optimization with relevant, recent data.
- The number of days for the warm-start window is now configurable. You can set this via the `recent_days_warm_start` key in the optimization job JSON file.