### PR TITLE
OOS（Out-of-Sample）検証において、シミュレーション結果の取引回数が常にゼロになる問題を修正しました。

### DIFF
--- a/optimizer/test_study.py
+++ b/optimizer/test_study.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+from pathlib import Path
+
+# Assuming the optimizer package is in the python path
+from optimizer import study
+
+class TestStudyHelpers(unittest.TestCase):
+
+    def test_unflatten_params(self):
+        """
+        Tests that the _unflatten_params function correctly converts
+        a flat dictionary to a nested dictionary.
+        """
+        flat_params = {
+            'spread_limit': 50,
+            'adaptive_position_sizing.enabled': True,
+            'adaptive_position_sizing.num_trades': 10,
+            'signal.slope_filter.enabled': False,
+            'signal.slope_filter.period': 5
+        }
+        expected_nested_params = {
+            'spread_limit': 50,
+            'adaptive_position_sizing': {
+                'enabled': True,
+                'num_trades': 10
+            },
+            'signal': {
+                'slope_filter': {
+                    'enabled': False,
+                    'period': 5
+                }
+            }
+        }
+        self.assertEqual(study._unflatten_params(flat_params), expected_nested_params)
+
+    def test_unflatten_params_empty(self):
+        """Tests that the function handles an empty dictionary correctly."""
+        self.assertEqual(study._unflatten_params({}), {})
+
+    def test_unflatten_params_no_nesting(self):
+        """Tests that the function handles a dictionary with no dots."""
+        params = {'a': 1, 'b': 'hello', 'c': False}
+        self.assertEqual(study._unflatten_params(params), params)
+
+    @patch('optimizer.study._save_best_parameters')
+    @patch('optimizer.study.run_simulation')
+    def test_perform_oos_validation_uses_unflattened_params(
+        self, mock_run_simulation, mock_save_best_parameters
+    ):
+        """
+        Tests that _perform_oos_validation unnests params before calling
+        run_simulation and _save_best_parameters.
+        """
+        # 1. Setup
+        flat_params = {'a.b': 1, 'c': True}
+        nested_params = {'a': {'b': 1}, 'c': True}
+
+        # Mock candidate list as created by _get_oos_candidates
+        candidates = [{'params': flat_params, 'source': 'is_rank_1'}]
+
+        # Mock simulation result to pass validation
+        mock_run_simulation.return_value = {
+            'TotalTrades': 100,
+            'SharpeRatio': 2.0,
+            'ProfitFactor': 1.5
+        }
+
+        # 2. Execute
+        # We need a dummy path that exists
+        dummy_path = Path('.')
+        result = study._perform_oos_validation(candidates, dummy_path)
+
+        # 3. Assert
+        self.assertTrue(result) # Should pass validation and return True
+
+        # Check that run_simulation was called with the NESTED params
+        mock_run_simulation.assert_called_once_with(nested_params, dummy_path)
+
+        # Check that _save_best_parameters was also called with the NESTED params
+        mock_save_best_parameters.assert_called_once_with(nested_params)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### 問題の原因

IS（In-Sample）最適化では、パラメータはネストされた辞書としてシミュレーションに渡されていました。しかし、OOS検証では、Optunaの `trial.params` から取得したフラットな（ドット区切りのキーを持つ）辞書がそのまま渡されていました。

このフラットな辞書がJinja2テンプレートで処理される際、ネスト構造が期待されているため正しく値が展開されず、結果として全ての機能が無効化された設定ファイルが生成されていました。これが、OOSで取引が一切行われなかった原因です。

### 修正内容

1.  **パラメータ変換関数の追加**: フラットなパラメータ辞書をネスト構造に変換するヘルパー関数 `_unflatten_params` を `optimizer/study.py` に追加しました。
2.  **OOS検証ロジックの修正**: OOS検証を行う `_perform_oos_validation` 関数内で、シミュレーションを実行する前に `_unflatten_params` を呼び出し、パラメータを正しいネスト構造に変換するように修正しました。
3.  **ユニットテストの追加**: 上記の修正を検証するため、`optimizer/test_study.py` に新しいユニットテストを追加しました。これにより、パラメータ変換ロジックの正しさと、OOS検証フローが意図通りに動作することが保証されます。