### PR TITLE
`optimizer/simulation.py` 内で発生していた `NameError: name '_finalize_for_ya…

### DIFF
--- a/optimizer/simulation.py
+++ b/optimizer/simulation.py
@@ -33,7 +33,7 @@ def run_simulation(params: dict, sim_csv_path: Path) -> dict:
         # Setup a Jinja2 environment that uses a custom finalizer for YAML compatibility
         env = Environment(
             loader=FileSystemLoader(searchpath=config.PARAMS_DIR),
-            finalize=_finalize_for_yaml
+            finalize=finalize_for_yaml
         )
         template = env.get_template(config.CONFIG_TEMPLATE_PATH.name)
         config_yaml_str = template.render(params)


### PR DESCRIPTION
…ml' is not defined` を修正します。

以前のリファクタリングで `_finalize_for_yaml` 関数を `utils.py` に移動し `finalize_for_yaml` にリネームしましたが、`simulation.py` 内での関数名の更新が漏れていました。このコミットでタイポを修正し、正しい関数名を参照するようにします。

度重なる修正となりましたが、これにより、最初のエラー報告からの一連の問題がすべて解決されます。
- YAMLのブール値レンダリング問題 (→ `finalize_for_yaml` で解決)
- OOS検証時のパラメータ構造の不整合問題 (→ `nest_params` で解決)
- 上記修正時に混入した `NameError` (→ 今回のコミットで解決)

追加したユニットテストにより、これらの修正の堅牢性を確認済みです。