### PR TITLE
リファクタ: optimizerのパラメータ変換ロジックを堅牢化

### DIFF
--- a/optimizer/test_utils.py
+++ b/optimizer/test_utils.py
@@ -145,5 +145,41 @@ class TestUtils(unittest.TestCase):
         self.maxDiff = None
         self.assertDictEqual(nested_params, expected_nested_params)
 
+    def test_nest_params_handles_numpy_types(self):
+        """
+        Tests that nest_params correctly handles numpy data types, converting
+        them to standard Python types. This is crucial because Optuna dataframes
+        often use numpy types.
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("Numpy not installed, skipping numpy type test.")
+
+        # Simulate input from a pandas/numpy environment
+        flat_params_numpy = {
+            'spread_limit': np.int64(80),
+            'lot_max_ratio': np.float64(0.9),
+            'adaptive_position_sizing_enabled': np.bool_(True),
+            'long_tp': np.int32(100),
+        }
+
+        nested_params = nest_params(flat_params_numpy)
+
+        # Check top-level types
+        self.assertIsInstance(nested_params['spread_limit'], int, "spread_limit should be int")
+        self.assertIsInstance(nested_params['lot_max_ratio'], float, "lot_max_ratio should be float")
+
+        # Check nested types
+        adaptive_sizing = nested_params['adaptive_position_sizing']
+        self.assertIsInstance(adaptive_sizing['enabled'], bool, "enabled should be bool")
+
+        long_params = nested_params['long']
+        self.assertIsInstance(long_params['tp'], int, "long_tp should be int")
+
+        # Also verify a default value's type
+        self.assertIsInstance(long_params['obi_threshold'], float, "obi_threshold should be float")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/optimizer/utils.py
+++ b/optimizer/utils.py
@@ -1,3 +1,5 @@
+import numbers
+
 def finalize_for_yaml(value):
     """
     Custom Jinja2 finalizer to ensure YAML-compatible output.
@@ -13,88 +15,114 @@ def nest_params(flat_params: dict) -> dict:
     Converts a flat dictionary of parameters (from Optuna) into a nested
     dictionary suitable for rendering the trade_config.yaml template.
 
-    This version uses a predefined mapping for clarity and robustness,
-    avoiding complex regex or brittle logic.
+    This refactored version builds the dictionary structure explicitly and
+    handles potential NumPy types by converting them to native Python types.
+    This ensures robustness and prevents serialization issues downstream.
 
     Args:
         flat_params: A flat dictionary where keys match the keys used in
-                     `objective.py`'s `trial.suggest_*` calls.
+                     `objective.py`'s `trial.suggest_*` calls. Can contain
+                     native Python or NumPy types.
 
     Returns:
-        A nested dictionary matching the YAML structure.
+        A nested dictionary with native Python types, matching the YAML structure.
     """
-    # Initialize the nested structure with default values
+    def get_and_convert(key, target_type):
+        """
+        Safely gets a value from the flat_params dictionary, converts it to the
+        target Python type, and handles missing keys or numpy types.
+        """
+        value = flat_params.get(key)
+        if value is None:
+            return None
+        # Handle numpy types (e.g., np.int64) by converting them to native types
+        if isinstance(value, numbers.Number):
+            return target_type(value)
+        # Handle boolean types, including np.bool_
+        if isinstance(value, (bool, numbers.Integral)): # Catches bool, np.bool_, int
+             if target_type == bool:
+                 return bool(value)
+        return target_type(value)
+
+    # A dictionary mapping leaf keys to their required Python type
+    type_map = {
+        'spread_limit': int, 'lot_max_ratio': float, 'order_ratio': float,
+        'adaptive_position_sizing_enabled': bool, 'adaptive_num_trades': int,
+        'adaptive_reduction_step': float, 'adaptive_min_ratio': float,
+        'long_tp': int, 'long_sl': int, 'short_tp': int, 'short_sl': int,
+        'hold_duration_ms': int, 'obi_weight': float, 'ofi_weight': float,
+        'cvd_weight': float, 'micro_price_weight': float, 'composite_threshold': float,
+        'slope_filter_enabled': bool, 'slope_period': int, 'slope_threshold': float,
+        'ewma_lambda': float, 'dynamic_obi_enabled': bool, 'volatility_factor': float,
+        'min_threshold_factor': float, 'max_threshold_factor': float, 'twap_enabled': bool,
+        'twap_max_order_size_btc': float, 'twap_interval_seconds': int,
+        'twap_partial_exit_enabled': bool, 'twap_profit_threshold': float,
+        'twap_exit_ratio': float, 'risk_max_drawdown_percent': int,
+        'risk_max_position_ratio': float
+    }
+
+    p = lambda key: get_and_convert(key, type_map.get(key, str))
+
     nested_params = {
-        'adaptive_position_sizing': {},
-        'long': {'obi_threshold': 0.0},
-        'short': {'obi_threshold': 0.0},
+        'spread_limit': p('spread_limit'),
+        'lot_max_ratio': p('lot_max_ratio'),
+        'order_ratio': p('order_ratio'),
+        'adaptive_position_sizing': {
+            'enabled': p('adaptive_position_sizing_enabled'),
+            'num_trades': p('adaptive_num_trades'),
+            'reduction_step': p('adaptive_reduction_step'),
+            'min_ratio': p('adaptive_min_ratio'),
+        },
+        'long': { 'tp': p('long_tp'), 'sl': p('long_sl') },
+        'short': { 'tp': p('short_tp'), 'sl': p('short_sl') },
         'signal': {
-            'slope_filter': {}
+            'hold_duration_ms': p('hold_duration_ms'),
+            'obi_weight': p('obi_weight'), 'ofi_weight': p('ofi_weight'),
+            'cvd_weight': p('cvd_weight'), 'micro_price_weight': p('micro_price_weight'),
+            'composite_threshold': p('composite_threshold'),
+            'slope_filter': {
+                'enabled': p('slope_filter_enabled'), 'period': p('slope_period'),
+                'threshold': p('slope_threshold'),
+            },
         },
         'volatility': {
-            'dynamic_obi': {}
+            'ewma_lambda': p('ewma_lambda'),
+            'dynamic_obi': {
+                'enabled': p('dynamic_obi_enabled'), 'volatility_factor': p('volatility_factor'),
+                'min_threshold_factor': p('min_threshold_factor'),
+                'max_threshold_factor': p('max_threshold_factor'),
+            },
         },
-        'twap': {},
-        'risk': {}
+        'twap': {
+            'enabled': p('twap_enabled'), 'max_order_size_btc': p('twap_max_order_size_btc'),
+            'interval_seconds': p('twap_interval_seconds'),
+            'partial_exit_enabled': p('twap_partial_exit_enabled'),
+            'profit_threshold': p('twap_profit_threshold'), 'exit_ratio': p('twap_exit_ratio'),
+        },
+        'risk': {
+            'max_drawdown_percent': p('risk_max_drawdown_percent'),
+            'max_position_ratio': p('risk_max_position_ratio'),
+        },
     }
 
-    # Map flat keys to their location in the nested dictionary
-    # The key is the flat param name, the value is a tuple path.
-    key_map = {
-        'spread_limit': ('spread_limit',),
-        'lot_max_ratio': ('lot_max_ratio',),
-        'order_ratio': ('order_ratio',),
-        # adaptive_position_sizing
-        'adaptive_position_sizing_enabled': ('adaptive_position_sizing', 'enabled'),
-        'adaptive_num_trades': ('adaptive_position_sizing', 'num_trades'),
-        'adaptive_reduction_step': ('adaptive_position_sizing', 'reduction_step'),
-        'adaptive_min_ratio': ('adaptive_position_sizing', 'min_ratio'),
-        # long
-        'long_tp': ('long', 'tp'),
-        'long_sl': ('long', 'sl'),
-        # short
-        'short_tp': ('short', 'tp'),
-        'short_sl': ('short', 'sl'),
-        # signal
-        'hold_duration_ms': ('signal', 'hold_duration_ms'),
-        'obi_weight': ('signal', 'obi_weight'),
-        'ofi_weight': ('signal', 'ofi_weight'),
-        'cvd_weight': ('signal', 'cvd_weight'),
-        'micro_price_weight': ('signal', 'micro_price_weight'),
-        'composite_threshold': ('signal', 'composite_threshold'),
-        # signal.slope_filter
-        'slope_filter_enabled': ('signal', 'slope_filter', 'enabled'),
-        'slope_period': ('signal', 'slope_filter', 'period'),
-        'slope_threshold': ('signal', 'slope_filter', 'threshold'),
-        # volatility
-        'ewma_lambda': ('volatility', 'ewma_lambda'),
-        # volatility.dynamic_obi
-        'dynamic_obi_enabled': ('volatility', 'dynamic_obi', 'enabled'),
-        'volatility_factor': ('volatility', 'dynamic_obi', 'volatility_factor'),
-        'min_threshold_factor': ('volatility', 'dynamic_obi', 'min_threshold_factor'),
-        'max_threshold_factor': ('volatility', 'dynamic_obi', 'max_threshold_factor'),
-        # twap
-        'twap_enabled': ('twap', 'enabled'),
-        'twap_max_order_size_btc': ('twap', 'max_order_size_btc'),
-        'twap_interval_seconds': ('twap', 'interval_seconds'),
-        'twap_partial_exit_enabled': ('twap', 'partial_exit_enabled'),
-        'twap_profit_threshold': ('twap', 'profit_threshold'),
-        'twap_exit_ratio': ('twap', 'exit_ratio'),
-        # risk
-        'risk_max_drawdown_percent': ('risk', 'max_drawdown_percent'),
-        'risk_max_position_ratio': ('risk', 'max_position_ratio'),
-    }
+    def remove_none_recursively(d):
+        if not isinstance(d, dict):
+            return d
+        return {k: remove_none_recursively(v) for k, v in d.items() if v is not None}
 
-    # Populate the nested dictionary from the flat parameters
-    for flat_key, value in flat_params.items():
-        if flat_key in key_map:
-            path = key_map[flat_key]
-            current_level = nested_params
-            for i, part in enumerate(path):
-                if i == len(path) - 1:
-                    current_level[part] = value
-                else:
-                    current_level = current_level.setdefault(part, {})
-        # Note: Unmapped keys from flat_params are ignored.
+    final_params = remove_none_recursively(nested_params)
 
-    return nested_params
+    # Restore required structure after removing None values
+    if 'long' not in final_params: final_params['long'] = {}
+    final_params['long']['obi_threshold'] = 0.0
+    if 'short' not in final_params: final_params['short'] = {}
+    final_params['short']['obi_threshold'] = 0.0
+    if 'adaptive_position_sizing' not in final_params: final_params['adaptive_position_sizing'] = {}
+    if 'signal' not in final_params: final_params['signal'] = {}
+    if 'slope_filter' not in final_params.get('signal', {}): final_params['signal']['slope_filter'] = {}
+    if 'volatility' not in final_params: final_params['volatility'] = {}
+    if 'dynamic_obi' not in final_params.get('volatility', {}): final_params['volatility']['dynamic_obi'] = {}
+    if 'twap' not in final_params: final_params['twap'] = {}
+    if 'risk' not in final_params: final_params['risk'] = {}
+
+    return final_params


### PR DESCRIPTION
OOS(Out-of-Sample)検証時に、すべての結果が trades=0 となる問題を修正します。

問題の原因は、OOS検証で使われるパラメータをフラットな辞書からネスト構造へ変換する `nest_params` 関数のロジックが、特定の条件下で不完全な設定ファイルを生成してしまう可能性があった点です。 特に、OptunaやPandasから渡される可能性のあるNumPyのデータ型が、後続のJinja2テンプレートエンジンで正しく解釈されないリスクがありました。

この修正では、`optimizer/utils.py` の `nest_params` 関数を全面的にリファクタリングしました。新しい実装は、`setdefault` のような副作用に依存せず、より明示的にネスト構造を構築します。また、入力値がNumPyの型であった場合に、それを標準のPython型（int, float, bool）へ確実に変換する処理を追加しました。

あわせて、このNumPyの型変換を検証するためのユニットテストを `optimizer/test_utils.py` に追加し、すべてのテストがパスすることを確認済みです。 これにより、OOS検証時に常に正しく構造化された設定ファイルが生成されるようになり、問題が解決される見込みです。