### PR TITLE
`optimizer`サービスのデータエクスポート処理中に、存在しない`trade_config.yaml`を読み込もうとしてエラーが発生…

### DIFF
--- a/optimizer/data.py
+++ b/optimizer/data.py
@@ -31,8 +31,7 @@ def export_and_split_data(total_hours: float, oos_hours: float) -> Tuple[Union[P
     cmd = [
         'go', 'run', 'cmd/export/main.go',
         f'--hours-before={int(total_hours)}',
-        '--no-zip',
-        f'--trade-config={config.BEST_CONFIG_OUTPUT_PATH}'
+        '--no-zip'
     ]
 
     try:


### PR DESCRIPTION
…する問題を修正しました。

この問題は、エクスポート用のGoスクリプト(`cmd/export/main.go`)が、まだ最適化によって生成されていない`trade_config.yaml`に依存していることが原因でした。

修正内容は以下の2点です。
1. `cmd/export/main.go`を修正し、`trade_config.yaml`が存在しない場合でもエラーとせず、処理を続行できるようにしました。
2. `optimizer/data.py`を修正し、Goスクリプトを呼び出す際に不要な`--trade-config`フラグを渡さないようにしました。

これにより、循環依存が解消され、最適化プロセスの初回実行時やクリーンな状態からでも、データエクスポートが正常に行われるようになります。