### PR TITLE
fix(optimizer): 'adaptive_position_sizing' is undefined エラーを修正

### DIFF
--- a/optimizer/objective.py
+++ b/optimizer/objective.py
@@ -96,8 +96,10 @@ class Objective:
         # Run multiple simulations with small jitters to evaluate parameter stability.
         jitter_results = [summary] # Start with the result from the original params
         for i in range(config.STABILITY_CHECK_N_RUNS):
-            jittered_params = self._get_jittered_params(trial)
-            jitter_summary = simulation.run_simulation(jittered_params, sim_csv_path)
+            jittered_flat_params = self._get_jittered_params(trial)
+            # The jittered params are flat, so they must be nested before simulation.
+            jittered_nested_params = nest_params(jittered_flat_params)
+            jitter_summary = simulation.run_simulation(jittered_nested_params, sim_csv_path)
             if jitter_summary:
                 jitter_results.append(jitter_summary)
 


### PR DESCRIPTION
Optunaによるパラメータ最適化の安定性分析(Stability Analysis)の際、
揺らぎを与えたパラメータ(jittered_params)がネストされた辞書形式に変換されずに
シミュレーション関数に渡されていたため、Jinja2テンプレートで
'adaptive_position_sizing' is undefined エラーが発生していました。

`_get_jittered_params` から返されたフラットなパラメータを `nest_params` ユーティリティ 関数で適切にネストされた形式に変換することで、この問題を解決しました。