### PR TITLE
fix(optimizer): YAMLのブール値が小文字で出力されるように修正

### DIFF
--- a/optimizer/simulation.py
+++ b/optimizer/simulation.py
@@ -36,7 +36,7 @@ def run_simulation(params: dict, sim_csv_path: Path) -> dict:
             finalize=finalize_for_yaml
         )
         template = env.get_template(config.CONFIG_TEMPLATE_PATH.name)
-        config_yaml_str = template.render(params)
+        config_yaml_str = template.render(**params)
 
 
         # Use delete=False, so the file is not deleted when the 'with' block exits.

--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -229,7 +229,7 @@ def _save_best_parameters(flat_params: dict):
             finalize=finalize_for_yaml
         )
         template = env.get_template(config.CONFIG_TEMPLATE_PATH.name)
-        config_str = template.render(nested_params)
+        config_str = template.render(**nested_params)
 
         with open(config.BEST_CONFIG_OUTPUT_PATH, 'w') as f:
             f.write(config_str)


### PR DESCRIPTION
optimizerが生成するtrade_config.yamlにおいて、ブール値が 'True' や 'False' のように大文字で始まっていました。 YAMLの仕様上は有効ですが、一般的な慣習やファイル内のコメントに合わせて、小文字の 'true', 'false' で出力されるべきです。

原因は、Jinja2テンプレートをレンダリングする際の `template.render()` メソッドの呼び出し方にありました。 辞書を直接渡していたため、テンプレート変数を展開する際のコンテキストが異なり、ブール値を小文字化する `finalize` 関数が適用されていませんでした。

`template.render(**params)` のように辞書を展開してキーワード引数として渡すように修正することで、`finalize` 関数が正しく動作するようにしました。 この修正を `optimizer/study.py` と `optimizer/simulation.py` の両方に適用しました。