### PR TITLE
fix(export): Mount params volume for export-sim-data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - .:/app
       - ./.env:/app/.env:ro
       - ./config:/app/config:ro
+      - ./data/params:/data/params
     working_dir: /app
     environment:
       - DB_HOST=timescaledb


### PR DESCRIPTION
The `make export-sim-data` command was failing with a fatal error: `Failed to initialize any configuration`.

This was caused by the `builder` service in `docker-compose.yml` lacking a volume mount for the `./data/params` directory. The export script expects to find `/data/params/trade_config.yaml`, and while it has logic to proceed without it, a flaw in the config loading function caused it to fail when the file was not present.

This change adds the `./data/params:/data/params` volume mount to the `builder` service, aligning its configuration with the `bot` and `optimizer` services which also require access to this directory. This ensures the necessary configuration files are available to the export script.

Verification was attempted, but the execution environment prevented running `docker compose` commands, which are required for both the `export-sim-data` and `test` make targets. The fix directly addresses the identified root cause.