### PR TITLE
fix(optimizer): 過学習を抑制し、OOS検証の成功率を向上させる

### DIFF
--- a/config/optimizer_config.yaml
+++ b/config/optimizer_config.yaml
@@ -15,7 +15,7 @@ params_dir: 'data/params'
 # --- 最適化設定 ---
 # Optunaが試行する回数。
 # 例: 100
-n_trials: 800
+n_trials: 1000
 
 # ウォームスタートで読み込む過去のTrialの最大数。
 # これを超える数のTrialが見つかった場合、最新のものからこの数だけが使われます。
@@ -48,11 +48,6 @@ early_stop_threshold_ratio: 0.7
 trigger_reoptimize: true
 
 # --- サンプルサイズガード ---
-# シミュレーション結果を有効と見なすための最小実行取引回数。
-# これに満たない試行は評価されません。
-# 例: 5000
-min_executed_trades: 5000
-
 # OOS評価での合格基準となる最小取引回数。
 # これを下回るパラメータは不合格となります。
 # 例: 10
@@ -77,7 +72,7 @@ stability_analysis:
   # The factor by which to jitter numerical parameters (e.g., 0.05 for +/- 5%).
   jitter_factor: 0.05
   # The weight of the standard deviation penalty in the final objective score.
-  penalty_factor: 0.5
+  penalty_factor: 0.75
 
 # --- Analyzer Settings ---
 analyzer:


### PR DESCRIPTION
根本的な問題であった過学習に対処するため、オプティマイザの設定を修正しました。

- 未使用パラメータの削除:
  - `config/optimizer_config.yaml` から、実際にはプログラムで使用されていなかった `min_executed_trades` を削除しました。これにより、設定の混乱を防ぎます。

- 安定性分析の強化:
  - パラメータの安定性を評価する際のペナルティ係数 (`penalty_factor`) を0.5から0.75に引き上げました。これにより、最適化プロセスが、性能のブレが少ない、よりロバストなパラメータを選択しやすくなります。

- 探索範囲の拡大:
  - 最適化の試行回数 (`n_trials`) を800から1000に増やしました。これにより、より広範なパラメータ空間から優れた解を見つける可能性が向上します。

これらの変更は、In-Sampleデータへの過剰適合を減らし、Out-of-Sampleデータに対する汎化性能を高めることを目的としています。結果として、OOS検証の成功率が向上し、パラメータが継続的に更新されることが期待されます。