### PR TITLE
Fix WFO runner build and configuration issues

### DIFF
--- a/cmd/wfo-runner/main.go
+++ b/cmd/wfo-runner/main.go
@@ -60,7 +60,7 @@ func main() {
 	log.Println("--- Starting Walk-Forward Optimization (WFO) Runner ---")
 
 	// 1. Load Configuration
-	cfg, err := loadConfig("../../config/optimizer_config.yaml")
+	cfg, err := loadConfig("config/optimizer_config.yaml")
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}

--- a/optimizer/Dockerfile.wfo
+++ b/optimizer/Dockerfile.wfo
@@ -2,7 +2,7 @@
 # The WFO runner is a Go application that orchestrates the optimization process by
 # calling the Python-based optimizer script for each cycle. Therefore, this image
 # needs to contain both the Go toolchain (to build the runner) and a Python
-g# environment (to run the optimizer script).
+# environment (to run the optimizer script).
 
 FROM python:3.9-slim
 


### PR DESCRIPTION
This commit addresses several issues that prevented the Walk-Forward Optimization (WFO) runner from executing successfully.

The following fixes have been implemented:
- Corrected a syntax error in `optimizer/Dockerfile.wfo` where a comment was mistyped as `g#` instead of `#`.
- Ensured the application has the necessary environment variables by creating a `.env` file from the sample.
- Fixed an incorrect, hardcoded file path in `cmd/wfo-runner/main.go` that was preventing the application from finding its configuration file. The path was corrected to work within the Docker container's file structure.