### PR TITLE
I've resolved an issue that was causing a `ModuleNotFoundError` for t…

### DIFF
--- a/cmd/wfo-runner/main.go
+++ b/cmd/wfo-runner/main.go
@@ -174,8 +174,10 @@ func executeCycle(cycle WFOCycle, nTrials int) error {
 		"--n-trials", fmt.Sprintf("%d", nTrials),
 	)
 
-	// Set the working directory for the python script relative to the Go binary
-	cmd.Dir = "../../" // Run from the repo root
+	// Set the working directory for the python script.
+	// The Dockerfile sets the WORKDIR to /app, which is the repository root.
+	// The wfo-runner binary is executed from there, so the Python script
+	// will inherit the correct working directory.
 
 	// Capture output for logging
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
…he `optimizer` module.

The problem was that the Python script was being executed from the wrong directory, which prevented the interpreter from finding the module.

I've corrected the execution environment so the script runs from the proper working directory. This fixes the error and allows the script to import the `optimizer` module successfully.