### PR TITLE
オプティマイザにおいて、パレートフロンティアが試行回数に比例して増加する問題を修正しました。

### DIFF
--- a/optimizer/objective.py
+++ b/optimizer/objective.py
@@ -76,7 +76,9 @@ class Objective:
         # a trial with 0 trades (SQN=0, PF=0, MaxDD=high). This prevents trials
         # that are pruned from bloating the Pareto front.
         def get_dominated_penalty():
-            return -1.0, 0.0, 1_000_000.0
+            # For the 3rd objective (MaxDD), a large negative value is unattractive
+            # because the direction is now 'maximize'.
+            return -1.0, 0.0, -1_000_000.0
 
         flat_params = self._suggest_parameters(trial)
         params = nest_params(flat_params)
@@ -161,7 +163,8 @@ class Objective:
         # may still prune based on the first objective if it's reported, but
         # we are not reporting intermediate values here.
 
-        return final_sqn, final_pf, final_mdd
+        # Return negative MDD because we want to maximize it (equivalent to minimizing MDD)
+        return final_sqn, final_pf, -final_mdd
 
     def _get_jittered_params(self, trial: optuna.Trial) -> dict:
         """

--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -32,7 +32,7 @@ def create_study(storage_path: str, study_name: str) -> optuna.Study:
     return optuna.create_study(
         study_name=study_name,
         storage=storage_path,
-        directions=['maximize', 'maximize', 'minimize'],  # SQN (max), ProfitFactor (max), MaxDD (min)
+        directions=['maximize', 'maximize', 'maximize'],  # SQN (max), ProfitFactor (max), -MaxDD (max)
         load_if_exists=False, # Each cycle should be a fresh study
         pruner=pruner,
         sampler=sampler


### PR DESCRIPTION
原因：
Optunaの多目的最適化において、目的関数の一つである最大ドローダウン(MaxDD)の最適化方向が正しく機能していなかったため、ほぼ全ての試行が非劣解としてパレートフロンティアに追加されていました。

修正内容：
1. `objective.py`にて、目的関数が返す最大ドローダウンの値を負数(-MaxDD)に変更しました。
2. `study.py`にて、Optunaの最適化方向をすべて`maximize`に統一しました。

これにより、最大ドローダウンを最小化する（-MaxDDを最大化する）という意図が明確になり、オプティマイザが効率的に有望な解を探索できるようになることが期待されます。