### PR TITLE
最適化パラメータ`long_obi_threshold`と`short_obi_threshold`の範囲を、より現実的な値に変更します。

### DIFF
--- a/optimizer/objective.py
+++ b/optimizer/objective.py
@@ -218,10 +218,10 @@ class Objective:
 
         # Long/Short Strategy
         # P1: Use log scale for sensitive thresholds
-        params['long_obi_threshold'] = trial.suggest_float('long_obi_threshold', 0.1, 1.0, log=True)
+        params['long_obi_threshold'] = trial.suggest_float('long_obi_threshold', 0.2, 0.4, log=False)
         params['long_tp'] = trial.suggest_int('long_tp', 50, 200)
         params['long_sl'] = trial.suggest_int('long_sl', -200, -50)
-        params['short_obi_threshold'] = trial.suggest_float('short_obi_threshold', 0.1, 1.0, log=True)
+        params['short_obi_threshold'] = trial.suggest_float('short_obi_threshold', 0.2, 0.4, log=False)
         params['short_tp'] = trial.suggest_int('short_tp', 50, 200)
         params['short_sl'] = trial.suggest_int('short_sl', -200, -50)
 


### PR DESCRIPTION
- 変更前: 0.1〜1.0 (log=True)
- 変更後: 0.2〜0.4 (log=False)

これにより、バックテストにおいて取引が全く発生しない問題を修正し、適切なトレード戦略の探索を可能にします。