### PR TITLE
fix(optimizer): WFOモードで最適化結果が保存されるように修正

### DIFF
--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -172,6 +172,10 @@ def analyze_and_validate(study: optuna.Study, oos_csv_path: Path, cycle_dir: Pat
         # Save the best parameters for this specific cycle
         _save_cycle_best_parameters(validation_result['params'], cycle_dir)
 
+        # Also update the global configuration file
+        logging.info("Updating global trade_config.yaml with the best parameters from this cycle.")
+        _save_global_best_parameters(validation_result['params'])
+
         # Combine IS and OOS results into a final summary for this cycle
         final_summary = {
             "cycle_id": cycle_dir.name,

--- a/optimizer/test_config_rendering.py
+++ b/optimizer/test_config_rendering.py
@@ -28,8 +28,7 @@ class TestConfigRendering(unittest.TestCase):
             -110,  # short_sl
         ]
         trial.suggest_float.side_effect = [
-            0.5,   # long_obi_threshold
-            0.6,   # short_obi_threshold
+            # Note: long_obi_threshold and short_obi_threshold are removed
             1.5,   # obi_weight
             1.4,   # ofi_weight
             1.3,   # cvd_weight
@@ -72,8 +71,8 @@ class TestConfigRendering(unittest.TestCase):
             'adaptive_position_sizing': {
                 'enabled': False, 'num_trades': 10, 'reduction_step': 0.8, 'min_ratio': 0.5
             },
-            'long': {'obi_threshold': 0.5, 'tp': 100, 'sl': -100},
-            'short': {'obi_threshold': 0.6, 'tp': 110, 'sl': -110},
+            'long': {'tp': 100, 'sl': -100},
+            'short': {'tp': 110, 'sl': -110},
             'signal': {
                 'hold_duration_ms': 500, 'cvd_window_minutes': 1, 'obi_weight': 1.5,
                 'ofi_weight': 1.4, 'cvd_weight': 1.3, 'micro_price_weight': 0.4,


### PR DESCRIPTION
WFO (Walk-Forward Optimization) モードで実行した際に、最適化されたパラメータがグローバルな `trade_config.yaml` に保存されていませんでした。 このモードではサイクルごとの `best_params.json` は作成されていましたが、あなたが期待するメインの設定ファイルは更新されていませんでした。

`optimizer/study.py` の `analyze_and_validate` 関数を修正し、OOS (Out-of-Sample) 検証に成功したサイクルで最も良かったパラメータが `data/params/trade_config.yaml` にも保存されるようにしました。

また、この修正作業中に発見した、`optimizer/test_config_rendering.py` の壊れていたテストも修正しました。