### PR TITLE
Fix: ボットが動的しきい値を使用していなかった不具合を修正

### DIFF
--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -194,9 +194,12 @@ func (e *SignalEngine) Evaluate(currentTime time.Time, obiValue float64) *Tradin
 	}
 	compositeScore := obiComponent + ofiComponent + cvdComponent + microPriceComponent
 
+	longThreshold := e.GetCurrentLongOBIThreshold()
+	shortThreshold := e.GetCurrentShortOBIThreshold()
+
 	logger.Debugf(
-		"[SignalCalc] Composite Score: %.4f (Thr: %.4f) | OBI: %.4f (Val: %.4f, W: %.2f) | OFI: %.4f (Val: %.4f, W: %.2f) | CVD: %.4f (Val: %.4f, W: %.2f) | MicroPrice: %.4f (Diff: %.4f, W: %.2f)",
-		compositeScore, e.config.CompositeThreshold,
+		"[SignalCalc] Composite Score: %.4f (LongThr: %.4f, ShortThr: %.4f) | OBI: %.4f (Val: %.4f, W: %.2f) | OFI: %.4f (Val: %.4f, W: %.2f) | CVD: %.4f (Val: %.4f, W: %.2f) | MicroPrice: %.4f (Diff: %.4f, W: %.2f)",
+		compositeScore, longThreshold, shortThreshold,
 		obiComponent, obiValue, e.config.OBIWeight,
 		ofiComponent, e.ofiValue, e.config.OFIWeight,
 		cvdComponent, e.cvdValue, e.config.CVDWeight,
@@ -205,9 +208,9 @@ func (e *SignalEngine) Evaluate(currentTime time.Time, obiValue float64) *Tradin
 
 	// --- 2. Determine Raw Signal from Score ---
 	rawSignal := SignalNone
-	if compositeScore >= e.config.CompositeThreshold {
+	if compositeScore >= longThreshold {
 		rawSignal = SignalLong
-	} else if compositeScore <= -e.config.CompositeThreshold {
+	} else if compositeScore <= shortThreshold {
 		rawSignal = SignalShort
 	}
 
@@ -261,9 +264,9 @@ func (e *SignalEngine) Evaluate(currentTime time.Time, obiValue float64) *Tradin
 	// A "stable" signal (well beyond the threshold) can be confirmed faster.
 	isStableSignal := false
 	stableThresholdFactor := 1.5
-	if e.currentSignal == SignalLong && compositeScore >= e.config.CompositeThreshold*stableThresholdFactor {
+	if e.currentSignal == SignalLong && compositeScore >= longThreshold*stableThresholdFactor {
 		isStableSignal = true
-	} else if e.currentSignal == SignalShort && compositeScore <= -e.config.CompositeThreshold*stableThresholdFactor {
+	} else if e.currentSignal == SignalShort && compositeScore <= shortThreshold*stableThresholdFactor {
 		isStableSignal = true
 	}
 


### PR DESCRIPTION
- `internal/signal/signal.go` の `Evaluate` 関数を修正し、ハードコードされた `CompositeThreshold` の代わりに、`GetCurrentLongOBIThreshold` と `GetCurrentShortOBIThreshold` から計算される動的しきい値を使用するように変更しました。
- これにより、オプティマイザによって調整された動的しきい値パラメータが、実際の取引ロジックに正しく反映されるようになります。
- 安定シグナル (`isStableSignal`) の判定ロジックも、同様に動的しきい値を使用するように修正しました。
- デバッグログを更新し、固定しきい値の代わりに、計算されたlong/shortの動的しきい値を表示するようにしました。