### PR TITLE
feat(optimizer): Improve robustness against overfitting

### DIFF
--- a/config/optimizer_config.yaml
+++ b/config/optimizer_config.yaml
@@ -22,7 +22,7 @@ n_trials: 1000
 warm_start_max_trials: 100
 
 # min_trades_for_pruning: In-Sample(IS)最適化中に、ここで設定した取引回数に満たない試行を枝刈り（pruning）します。
-min_trades_for_pruning: 5
+min_trades_for_pruning: 10
 
 # coarse_to_fine: Coarse-to-Fine（粗から密へ）探索の設定。
 coarse_to_fine:
@@ -69,7 +69,7 @@ objective_weights:
   # 取引回数
   trades: 0.5
   # 約定実現率: シグナル確定数に対する実際の取引数の割合。オーバーフィットの抑制に重要。
-  realization_rate: 1.5
+  realization_rate: 2.0
 
 # stability_analysis: パラメータの安定性分析（ロバスト性チェック）の設定。
 stability_analysis:

--- a/optimizer/objective.py
+++ b/optimizer/objective.py
@@ -120,11 +120,12 @@ class Objective:
              logging.warning(f"Trial {trial.number}: Too many jittered simulations failed. Using original result without penalty.")
              jitter_summaries = [summary] # Use original summary if jitter runs fail
 
-        sqns, profit_factors, max_drawdowns = [], [], []
+        sqns, profit_factors, max_drawdowns, sharpe_ratios = [], [], [], []
         for res in jitter_summaries:
             sr = res.get('SharpeRatio', 0.0)
             trades = res.get('TotalTrades', 0)
             sqn = sr * np.sqrt(trades) if trades > 0 and sr is not None else 0.0
+            sharpe_ratios.append(sr)
             sqns.append(sqn)
             profit_factors.append(res.get('ProfitFactor', 0.0))
             max_drawdowns.append(res.get('MaxDrawdown', 0.0))
@@ -135,16 +136,24 @@ class Objective:
         std_pf = np.std(profit_factors)
         mean_mdd = np.mean(max_drawdowns)
         std_mdd = np.std(max_drawdowns)
+        std_sr = np.std(sharpe_ratios)
 
         # The final objective is penalized by the standard deviation
         lambda_penalty = config.STABILITY_PENALTY_FACTOR
-        final_sqn = mean_sqn - (lambda_penalty * std_sqn)
+        # Penalize by stability of SQN and Sharpe Ratio
+        final_sqn = mean_sqn - (lambda_penalty * std_sqn) - (lambda_penalty * std_sr)
         final_pf = mean_pf - (lambda_penalty * std_pf)
         final_mdd = mean_mdd + (lambda_penalty * std_mdd) # Add penalty for instability
 
         # --- Final Objective Calculation ---
         # Apply realization and execution rates as direct penalties
         final_sqn_penalized = final_sqn * realization_rate * execution_rate
+
+        # Add a new penalty for each unrealized trade to directly punish missed opportunities
+        unrealized_trades = trial.user_attrs.get("unrealized_trades", 0)
+        sqn_penalty_per_unrealized = 0.2
+        additive_penalty = unrealized_trades * sqn_penalty_per_unrealized
+        final_sqn_penalized -= additive_penalty
 
         # Store all calculated metrics in user_attrs for later analysis
         trial.set_user_attr("mean_sqn", mean_sqn)
@@ -188,11 +197,11 @@ class Objective:
         params['long_sl'] = trial.suggest_int('long_sl', -200, -50)
         params['short_tp'] = trial.suggest_int('short_tp', 50, 200)
         params['short_sl'] = trial.suggest_int('short_sl', -200, -50)
-        params['obi_weight'] = trial.suggest_float('obi_weight', 0.5, 2.0)
-        params['ofi_weight'] = trial.suggest_float('ofi_weight', 0.5, 2.0)
+        params['obi_weight'] = trial.suggest_float('obi_weight', 0.8, 1.2)
+        params['ofi_weight'] = trial.suggest_float('ofi_weight', 0.8, 1.2)
         params['cvd_weight'] = trial.suggest_float('cvd_weight', 0.0, 1.0)
         params['micro_price_weight'] = trial.suggest_float('micro_price_weight', 0.0, 0.5)
-        params['composite_threshold'] = trial.suggest_float('composite_threshold', 0.1, 0.25)
+        params['composite_threshold'] = trial.suggest_float('composite_threshold', 0.15, 0.25)
         params['ewma_lambda'] = trial.suggest_float('ewma_lambda', 0.05, 0.25, log=True)
         params['dynamic_obi_enabled'] = trial.suggest_categorical('dynamic_obi_enabled', [True, False])
         if params['dynamic_obi_enabled']:


### PR DESCRIPTION
I've introduced several changes to the optimization process to combat overfitting and promote the discovery of more robust trading parameters. I made these changes after analyzing the logs, which showed that in-sample (IS) performance wasn't generalizing to out-of-sample (OOS) data, resulting in no trades.

Here are the key modifications I made:

1.  **Enhanced Objective Function (`optimizer/objective.py`):**
    - I added a penalty for the standard deviation of the Sharpe Ratio during stability analysis. This favors strategies with stable risk-adjusted returns.
    - I applied an explicit, additive penalty for each unrealized trade (`unrealized_trades`). This more aggressively punishes strategies that generate signals that fail to execute.

2.  **Refined Parameter Search Space:**
    - I narrowed the search range for indicator weights (`obi_weight`, `ofi_weight`) to encourage more balanced models (`optimizer/objective.py`).
    - I raised the minimum `composite_threshold` for signal generation to filter out noise (`optimizer/objective.py`).

3.  **Stricter Optimization Configuration (`config/optimizer_config.yaml`):**
    - I increased the minimum number of trades required to avoid pruning (`min_trades_for_pruning`) from 5 to 10.
    - I increased the weight of the `realization_rate` in the objective function from 1.5 to 2.0, further emphasizing the importance of successful trade execution.

NOTE: I was unable to run the Python unit tests prior to this commit. I encountered an issue with insufficient disk space that prevented me from installing the necessary dependencies. However, since the changes are focused on the objective function's logic and configuration, I believe them to be safe.