### PR TITLE
botコンテナの起動エラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,18 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o /go/bin/obi-scalp-bot cmd/bot/main.go
 
 # ---- Final Image ----
-FROM scratch
+FROM alpine:latest
 
-# Copy the static binary from the builder stage
-COPY --from=builder /go/bin/obi-scalp-bot /obi-scalp-bot
+WORKDIR /app
+
+# Copy the entrypoint script with execute permissions
+COPY --chmod=755 --from=builder /app/entrypoint.sh /app/entrypoint.sh
+
+# Copy the static binary from the builder stage to a standard location
+COPY --from=builder /go/bin/obi-scalp-bot /usr/local/bin/obi-scalp-bot
+
 # Copy ca-certificates for TLS
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Command to run the application
-ENTRYPOINT ["/obi-scalp-bot"]
+# Set the entrypoint to our script
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,10 @@ services:
       dockerfile: Dockerfile
     container_name: obi-scalp-bot
     volumes:
-      - .:/app
       - ./.env:/app/.env:ro
       - ./data/params:/data/params
       - ./config:/app/config:ro
-    entrypoint: ["/app/entrypoint.sh"]
+    # The entrypoint is now defined in the Dockerfile.
     # The trade_config.yaml is now loaded from /data/params by default in the Go app
     command: ["-config", "/app/config/app_config.yaml"]
     env_file:


### PR DESCRIPTION
Dockerコンテナの起動時に発生していた `exec /app/entrypoint.sh: no such file or directory` エラーを修正しました。

主な変更点:
- `Dockerfile` を修正し、`entrypoint.sh` をイメージ内にコピーして実行権限を付与するようにしました。
- `scratch` イメージ内で `RUN` コマンドが使えない問題を解決するため、`COPY --chmod` を使用しました。
- Goバイナリのパスを `/usr/local/bin/` に統一し、`entrypoint.sh` と `docker-compose.yml` 内のパス参照を整合させました。
- `docker-compose.yml` から不要な `entrypoint` と `volume` のマウント指定を削除し、イメージの定義に従うように修正しました。
- `entrypoint.sh` を実行するために必要なシェル環境を提供するため、最終イメージを `scratch` から `alpine` に変更しました。

これにより、コンテナはホスト環境のファイル状態に依存せず、自己完結型で安定して起動するようになります。