### PR TITLE
optimizerサービスのDockerイメージサイズを削減するため、Dockerfileをマルチステージビルドに修正しました。

### DIFF
--- a/optimizer/Dockerfile
+++ b/optimizer/Dockerfile
@@ -1,27 +1,46 @@
-FROM python:3.11-alpine
+# ---- Builder Stage ----
+# This stage installs all build dependencies and Python packages.
+FROM python:3.11-alpine AS builder
 
-# Set the working directory in the container
+# Set the working directory
 WORKDIR /app
 
-# Install build dependencies, then install python packages, then remove build dependencies
+# Install build-time dependencies needed for compiling Python packages.
+# 'go' and 'libstdc++' are included to match the original Dockerfile's dependencies.
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev g++ go libstdc++
+
+# Copy the requirements file and install Python packages.
+# Using --no-cache-dir reduces the image size by not storing the cache.
 COPY ./optimizer/requirements.txt /app/requirements.txt
-RUN apk add --no-cache go libgomp libstdc++ && \
-    apk add --no-cache --virtual .build-deps gcc musl-dev g++ && \
-    pip install --no-cache-dir -r requirements.txt && \
-    apk del .build-deps
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Install runtime dependencies
-RUN apk add --no-cache libgomp
+# ---- Final Stage ----
+# This stage creates the final, lean image.
+FROM python:3.11-alpine
 
-# Copy the application's code into the container
+# Set the working directory
+WORKDIR /app
+
+# Install runtime dependencies.
+# 'libgomp' is required by scikit-learn at runtime.
+# 'libstdc++' is a common runtime library for C++ code.
+RUN apk add --no-cache libgomp libstdc++
+
+# Copy the installed Python packages from the builder stage.
+# This avoids the need for build tools in the final image.
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Copy the application's code into the container.
 COPY ./optimizer /app/optimizer
 
-# Set environment variables to control thread usage by numerical libraries
+# Set environment variables to control thread usage by numerical libraries,
+# which can help prevent performance issues with libraries like NumPy and SciPy.
 ENV OMP_NUM_THREADS=1 \
     OPENBLAS_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
     VECLIB_MAXIMUM_THREADS=1 \
     NUMEXPR_NUM_THREADS=1
 
-# The command to run the application
+# The command to run the application.
 CMD ["python", "-m", "optimizer.main"]


### PR DESCRIPTION
- ビルダーステージと最終ステージを分離しました。
- ビルダーステージでPythonライブラリのコンパイルとインストールを行います。
- 最終ステージでは、ビルド成果物と実行に必要なライブラリのみをコピーすることで、イメージサイズを削減します。
- scikit-learnの実行時依存関係である `libgomp` を最終ステージに追加しました。

これにより、ビルドツールなどが最終イメージに含まれなくなり、イメージが軽量化されます。