### PR TITLE
fix(optimizer): Use compiled Go binary instead of 'go run'

### DIFF
--- a/optimizer/data.py
+++ b/optimizer/data.py
@@ -37,7 +37,7 @@ def export_and_split_data(
     _cleanup_directory(config.SIMULATION_DIR)
 
     cmd = [
-        'go', 'run', 'cmd/export/main.go',
+        'export',
         f'--start={is_start_time}',
         f'--end={oos_end_time}',
         '--no-zip'
@@ -181,7 +181,7 @@ def export_and_split_data_for_daemon(total_hours: float, oos_hours: float) -> Tu
 
     import math
     cmd = [
-        'go', 'run', 'cmd/export/main.go',
+        'export',
         f'--hours-before={math.ceil(total_hours)}',
         '--no-zip'
     ]


### PR DESCRIPTION
The optimizer service was attempting to call `go run cmd/export/main.go` to export data. However, the final Docker image for the optimizer service does not include the Go compiler, only the pre-compiled `export` binary.

This change modifies the Python data exporting script to call the `export` binary directly, resolving the "Could not find 'go' executable" error.