### PR TITLE
fix(optimizer): Gracefully handle no-data case in WFA

### DIFF
--- a/optimizer/data.py
+++ b/optimizer/data.py
@@ -113,11 +113,8 @@ def _split_data_by_timestamp(full_dataset_path: Path, split_time_str: str, cycle
     data_lines = lines[1:]
 
     if not data_lines:
-        logging.warning("No data to split. Creating empty IS and OOS files.")
-        with open(is_path, 'w') as f_is, open(oos_path, 'w') as f_oos:
-            f_is.write(header)
-            f_oos.write(header)
-        return is_path, oos_path
+        logging.warning("No data to split. The exported file is empty.")
+        return None, None
 
     with open(is_path, 'w') as f_is, open(oos_path, 'w') as f_oos:
         f_is.write(header)
@@ -225,11 +222,8 @@ def _split_data_by_ratio(full_dataset_path: Path, total_hours: float, oos_hours:
     data_lines = lines[1:]
 
     if not data_lines:
-        logging.warning("No data to split. Creating empty IS and OOS files.")
-        with open(is_path, 'w') as f_is, open(oos_path, 'w') as f_oos:
-            f_is.write(header)
-            f_oos.write(header)
-        return is_path, oos_path
+        logging.warning("No data to split. The exported file is empty.")
+        return None, None
 
     try:
         # Determine the split time based on the timestamp of the last data line

--- a/optimizer/walk_forward.py
+++ b/optimizer/walk_forward.py
@@ -55,7 +55,9 @@ def run_walk_forward_analysis(job: dict) -> bool:
                 cycle_dir=fold_dir
             )
             if not train_csv or not validate_csv:
-                raise ValueError("Data export for fold failed.")
+                logging.warning(f"Skipping fold {fold_id} due to missing data for the period.")
+                all_fold_results.append({"status": "skipped", "reason": "No data available for this time period."})
+                continue
 
             # b. Create and run an Optuna study on the training data
             storage_path = f"sqlite:///{fold_dir / 'optuna-study.db'}"


### PR DESCRIPTION
The Walk-Forward Analysis (WFA) would previously create empty In-Sample and Out-of-Sample files if the data export for a given fold yielded no data. This would produce a confusing warning log and could lead to downstream errors.

This change modifies the data splitting functions to return `(None, None)` when there is no data to split, instead of creating empty files.

The WFA runner has been updated to handle this new return value. Instead of raising an error, it now logs that the fold is being skipped due to a lack of data and continues to the next fold. This makes the entire analysis process more robust and resilient to gaps in the data.