### PR TITLE
feat: 取引設定なしでデータ収集モードで起動できるようにする

### DIFF
--- a/internal/engine/execution_engine_test.go
+++ b/internal/engine/execution_engine_test.go
@@ -33,7 +33,7 @@ func setupTest(t *testing.T) (*httptest.Server, *config.Config) {
 				TimeoutSeconds: 1,
 			},
 		},
-		Trade: config.TradeConfig{
+		Trade: &config.TradeConfig{
 			OrderRatio:  0.1,
 			LotMaxRatio: 0.1,
 			Risk: config.RiskConfig{


### PR DESCRIPTION
取引設定ファイル（trade_config.yaml）が見つからない場合でも、アプリケーションがエラーで終了せず、取引板のデータ（order_book_updates）の収集を継続できるように改修しました。

これにより、取引パラメータが未設定の状態でも、市場データの収集を目的としてボットを稼働させることが可能になります。

変更の詳細は以下の通りです。

- `internal/config/config.go`:
  - `Config`構造体の`Trade`フィールドを`*TradeConfig`（ポインタ）に変更しました。これにより、取引設定がロードされなかった場合（`nil`）と、空の設定がロードされた場合を明確に区別できるようになります。
  - 設定ファイルの読み込みロジックを修正し、`trade_config.yaml`が存在しない場合はエラーを返さずに、`Trade`フィールドを`nil`のまま処理を続行するように変更しました。

- `cmd/bot/main.go`:
  - `cfg.Trade`にアクセスする前に`nil`チェックを追加し、null pointer dereferenceによるパニックを防止しました。
  - メインループ（`runMainLoop`）で、`cfg.Trade`が`nil`でない場合にのみ取引関連の機能（シグナル生成、注文監視など）を有効にする条件分岐を追加しました。
  - 起動時のログを改善し、取引設定が読み込まれなかった場合には、その旨を明確に通知するようにしました。

- `internal/engine/execution_engine_test.go`:
  - `Config`構造体の変更に合わせて、テストコード内のモック設定を更新しました。