### PR TITLE
fix: Prevent nil pointer panic in data collection mode

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -702,8 +702,6 @@ func runMainLoop(injector *do.Injector, f *flags, sigs chan<- os.Signal) {
 		// Live trading setup
 		cfg := do.MustInvoke[*config.Config](injector)
 		dbWriter, _ := do.Invoke[dbwriter.DBWriter](injector)
-		execEngine := do.MustInvoke[engine.ExecutionEngine](injector)
-		client := do.MustInvoke[*coincheck.Client](injector)
 
 		orderBook := indicator.NewOrderBook()
 		obiCalculator := indicator.NewOBICalculator(orderBook, 300*time.Millisecond)
@@ -720,6 +718,8 @@ func runMainLoop(injector *do.Injector, f *flags, sigs chan<- os.Signal) {
 
 		if cfg.Trade != nil {
 			logger.Info("Trade configuration loaded, starting trading routines.")
+			execEngine := do.MustInvoke[engine.ExecutionEngine](injector)
+			client := do.MustInvoke[*coincheck.Client](injector)
 			go processSignalsAndExecute(injector, obiCalculator, wsClient, nil)
 			go orderMonitor(ctx, execEngine, client, orderBook)
 			go positionMonitor(ctx, execEngine, orderBook)


### PR DESCRIPTION
The application would panic with a nil pointer dereference when running without a trade configuration (in data collection mode).

This was caused by the `runMainLoop` function unconditionally invoking trading-related services (`ExecutionEngine` and `CoincheckClient`) at startup, even when they were not needed. In data collection mode, these services might not be fully initialized, leading to the panic.

This commit fixes the issue by moving the invocation of these services inside the `if cfg.Trade != nil` block. This ensures that trading-related components are only initialized when a trade configuration is actually loaded, allowing the bot to run correctly in data collection mode without panicking.