### PR TITLE
fix: Prevent OBI calculator from running in data collection mode

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -702,8 +702,6 @@ func runMainLoop(injector *do.Injector, f *flags, sigs chan<- os.Signal) {
 		// Live trading setup
 		cfg := do.MustInvoke[*config.Config](injector)
 		dbWriter, _ := do.Invoke[dbwriter.DBWriter](injector)
-		execEngine := do.MustInvoke[engine.ExecutionEngine](injector)
-		client := do.MustInvoke[*coincheck.Client](injector)
 
 		orderBook := indicator.NewOrderBook()
 		obiCalculator := indicator.NewOBICalculator(orderBook, 300*time.Millisecond)
@@ -715,11 +713,13 @@ func runMainLoop(injector *do.Injector, f *flags, sigs chan<- os.Signal) {
 
 		orderBookHandler, tradeHandler := setupHandlers(orderBook, dbWriter, pair)
 
-		obiCalculator.Start(ctx)
 		wsClient := coincheck.NewWebSocketClient(orderBookHandler, tradeHandler)
 
 		if cfg.Trade != nil {
 			logger.Info("Trade configuration loaded, starting trading routines.")
+			execEngine := do.MustInvoke[engine.ExecutionEngine](injector)
+			client := do.MustInvoke[*coincheck.Client](injector)
+			obiCalculator.Start(ctx)
 			go processSignalsAndExecute(injector, obiCalculator, wsClient, nil)
 			go orderMonitor(ctx, execEngine, client, orderBook)
 			go positionMonitor(ctx, execEngine, orderBook)


### PR DESCRIPTION
When running in data collection mode (without a trade config), the OBICalculator would be started, but its consumer (`processSignalsAndExecute`) would not. This caused the calculator's output channel to fill up, leading to a stream of `OBICalculator output channel is full` warnings.

This commit fixes the issue by moving the `obiCalculator.Start(ctx)` call into the `if cfg.Trade != nil` block. This ensures the calculator is only started when the bot is in full trading mode and its results can be consumed.