### PR TITLE
TimescaleDBのリストア処理を修正し、Hypertableが正しく復元されるようにします。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,12 @@ else
 		$(DOCKER_CMD) exec -T timescaledb dropdb -U $(DB_USER) --if-exists $(DB_NAME); \
 		$(DOCKER_CMD) exec -T timescaledb createdb -U $(DB_USER) $(DB_NAME); \
 		$(DOCKER_CMD) exec -T timescaledb psql -U $(DB_USER) -d $(DB_NAME) -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"; \
-		cat ./db/backup/backup.dump | $(DOCKER_CMD) exec -T timescaledb pg_restore -U $(DB_USER) -d $(DB_NAME); \
+		echo "Restoring pre-data section (schema)..."; \
+		cat ./db/backup/backup.dump | $(DOCKER_CMD) exec -T timescaledb pg_restore --section=pre-data -U $(DB_USER) -d $(DB_NAME); \
+		echo "Restoring data section..."; \
+		cat ./db/backup/backup.dump | $(DOCKER_CMD) exec -T timescaledb pg_restore --section=data -U $(DB_USER) -d $(DB_NAME); \
+		echo "Restoring post-data section (indexes, constraints)..."; \
+		cat ./db/backup/backup.dump | $(DOCKER_CMD) exec -T timescaledb pg_restore --section=post-data -U $(DB_USER) -d $(DB_NAME); \
 		echo "Database restored successfully."; \
 	else \
 		echo "No backup file found, skipping restore."; \


### PR DESCRIPTION
### 問題点
- 従来のリストア処理では、`pg_restore`を一度だけ実行していました。
- これにより、データが挿入された後に`create_hypertable()`が実行され、テーブルが空ではないためにHypertableへの変換に失敗することがありました。

### 解決策
- TimescaleDBの公式ドキュメントで推奨されている3段階のリストア処理を実装します。
- `Makefile`の`restore`ターゲットを修正し、`pg_restore`を以下の3つのセクションに分けて実行するように変更しました。
    1. `--section=pre-data` (スキーマ定義)
    2. `--section=data` (データ)
    3. `--section=post-data` (インデックス、制約)
- これにより、空のHypertableが先に作成され、その後にデータが挿入されるため、リストアが安定して成功するようになります。