### PR TITLE
修正: 注文サイズ決定ロジックの不具合を修正

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -587,15 +587,6 @@ func processSignalsAndExecute(injector *do.Injector, obiCalculator *indicator.OB
 						}
 
 						orderAmount := currentCfg.Trade.OrderAmount
-						if liveEngine, ok := execEngine.(*engine.LiveExecutionEngine); ok {
-							balance, err := liveEngine.GetBalance()
-							if err != nil {
-								logger.Warnf("Failed to get balance for order sizing: %v", err)
-								continue
-							}
-							currentBtc, _ := strconv.ParseFloat(balance.Btc, 64)
-							orderAmount = currentBtc * currentCfg.Trade.OrderRatio
-						}
 
 						if orderAmount >= 0.001 {
 							tradeParams := engine.TradeParams{


### PR DESCRIPTION
取引が実行されない問題について調査した結果、注文サイズを決定するロジックに不具合があることが判明しました。

現在のコードでは、`trade_config.yaml`で意図されている固定の`OrderAmount`ではなく、非推奨の`OrderRatio`（残高比率）を用いて注文サイズを計算していました。これにより、意図しないサイズの注文が計算され、結果として取引の最小注文額を下回り、注文が実行されていませんでした。

このコミットでは`cmd/bot/main.go`を修正し、ドキュメントの記述通りに`OrderAmount`を直接使用するようにロジックを修正しました。これにより、設定ファイルで指定された通りの固定サイズで注文が実行されるようになります。

当初、`ENABLE_TRADE`環境変数の設定も問題かと推測しましたが、あなたからのフィードバックで、これは環境側で設定済みであることが確認できたため、関連する変更は取り消しました。