### PR TITLE
Refactor: Remove unused spread_limit parameter

### DIFF
--- a/config/optimizer_config.yaml
+++ b/config/optimizer_config.yaml
@@ -122,10 +122,6 @@ analyzer:
 # - type: "categorical" -> suggest_categorical(choices)
 #
 parameter_space:
-  spread_limit:
-    type: "int"
-    low: 20
-    high: 100
   long_tp:
     type: "int"
     low: 50

--- a/data/params/trade_config.yaml.template
+++ b/data/params/trade_config.yaml.template
@@ -17,11 +17,6 @@ pair: "btc_jpy"
 # order_amount: 1回の取引で発注する基本の量（ロット）。
 order_amount: 0.01
 
-# spread_limit: 取引を許可する最大スプレッド（円）。
-# これよりスプレッドが広い場合、不利な価格での約定を避けるため新規エントリーを見送ります。
-# [最適化対象]
-spread_limit: {{ spread_limit }}
-
 # entry_price_offset: エントリー価格のオフセット（円）。
 # 買い注文では best_ask + offset, 売り注文では best_bid - offset の価格で発注し、
 # 約定の可能性を高めます。スリッページコストとのトレードオフになります。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,6 @@ type TradeConfig struct {
 	Pair                   string                 `yaml:"pair"`
 	OrderAmount            float64                `yaml:"order_amount"`
 	EntryPriceOffset       float64                `yaml:"entry_price_offset"`
-	SpreadLimit            float64                `yaml:"spread_limit"`
 	LotMaxRatio            float64                `yaml:"lot_max_ratio"`
 	OrderRatio             float64                `yaml:"order_ratio"`
 	Long                   StrategyConf           `yaml:"long"`


### PR DESCRIPTION
The `spread_limit` parameter was defined in the trade configuration files and optimization settings, but it was not being used by the Go application logic.

This removes the parameter from the Go struct, the optimizer's parameter space, and the configuration template.