### PR TITLE
fix(optimizer): 適切な枝刈りとログ改善

### DIFF
--- a/config/optimizer_config.yaml
+++ b/config/optimizer_config.yaml
@@ -24,7 +24,7 @@ warm_start_max_trials: 100
 
 # min_trades_for_pruning: IS最適化中、取引回数がこの値に満たない試行を枝刈り（pruning）し、
 # 非効率な探索を早期に打ち切ります。
-min_trades_for_pruning: 5
+min_trades_for_pruning: 1
 
 # dd_penalty_threshold: 相対ドローダウンがこの閾値を超えた試行を枝刈りします。
 # (0.0 ~ 1.0 の範囲、大きいほど許容度が高い)

--- a/optimizer/objective.py
+++ b/optimizer/objective.py
@@ -88,26 +88,32 @@ class Objective:
         self._calculate_and_set_metrics(trial, summary, stderr_log)
 
         # --- Pruning ---
+        pruning_reason = None
         total_trades = trial.user_attrs.get("trades", 0)
         if total_trades < config.MIN_TRADES_FOR_PRUNING:
-            logging.debug(f"Trial {trial.number} pruned due to insufficient trades: {total_trades} < {config.MIN_TRADES_FOR_PRUNING}")
-            raise optuna.exceptions.TrialPruned()
+            pruning_reason = f"insufficient trades ({total_trades} < {config.MIN_TRADES_FOR_PRUNING})"
 
-        realization_rate = trial.user_attrs.get("realization_rate", 0.0)
-        confirmed_signals = trial.user_attrs.get("confirmed_signals", 0)
-        if confirmed_signals > 10 and realization_rate < 0.1:
-            logging.debug(f"Trial {trial.number} pruned due to low realization rate: {realization_rate:.2f}")
-            raise optuna.exceptions.TrialPruned()
+        if pruning_reason is None:
+            realization_rate = trial.user_attrs.get("realization_rate", 0.0)
+            confirmed_signals = trial.user_attrs.get("confirmed_signals", 0)
+            if confirmed_signals > 10 and realization_rate < 0.1:
+                pruning_reason = f"low realization rate ({realization_rate:.2f})"
 
-        relative_drawdown = trial.user_attrs.get("relative_drawdown", 1.0)
-        if relative_drawdown > config.DD_PENALTY_THRESHOLD:
-            logging.debug(f"Trial {trial.number} pruned for high relative drawdown: {relative_drawdown:.2%}")
-            raise optuna.exceptions.TrialPruned()
+        if pruning_reason is None:
+            relative_drawdown = trial.user_attrs.get("relative_drawdown", 1.0)
+            if relative_drawdown > config.DD_PENALTY_THRESHOLD:
+                pruning_reason = f"high relative drawdown ({relative_drawdown:.2%})"
 
-        execution_rate = trial.user_attrs.get("execution_rate", 0.0)
-        if execution_rate < 0.5:
-            logging.debug(f"Trial {trial.number} pruned due to low execution rate: {execution_rate:.2f}")
-            raise optuna.exceptions.TrialPruned()
+        if pruning_reason is None:
+            execution_rate = trial.user_attrs.get("execution_rate", 0.0)
+            if execution_rate < 0.5:
+                pruning_reason = f"low execution rate ({execution_rate:.2f})"
+
+        if pruning_reason:
+            # Store the reason in the trial's user attributes for analysis
+            trial.set_user_attr("pruning_reason", pruning_reason)
+            logging.debug(f"Trial {trial.number} pruned due to {pruning_reason}")
+            raise optuna.exceptions.TrialPruned(pruning_reason)
 
         # --- Stability Analysis (Objective Regularization) ---
         # This is computationally expensive and should only be run during the fine-tuning phase.

--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -58,6 +58,21 @@ def _run_single_phase_optimization(
         callbacks=[callback_with_n_trials]
     )
 
+    # --- Log Pruning Statistics ---
+    pruned_trials = study.get_trials(deepcopy=False, states=[optuna.trial.TrialState.PRUNED])
+    if pruned_trials:
+        logging.info(f"--- Pruning Summary for {phase_name} ---")
+        logging.info(f"{len(pruned_trials)} out of {len(study.trials)} trials were pruned.")
+
+        # Count reasons
+        from collections import Counter
+        reasons = [t.user_attrs.get("pruning_reason", "Unknown") for t in pruned_trials]
+        reason_counts = Counter(reasons)
+
+        logging.info("Pruning reasons:")
+        for reason, count in reason_counts.items():
+            logging.info(f"  - {reason}: {count} times")
+
 def run_optimization(study: optuna.Study, is_csv_path: Path, n_trials: int, storage_path: str):
     """
     Runs the main optimization loop for a given study.

--- a/optimizer/test_config_rendering.py
+++ b/optimizer/test_config_rendering.py
@@ -21,21 +21,22 @@ class TestConfigRendering(unittest.TestCase):
         mock_study.user_attrs = {} # Objective expects user_attrs to exist
 
         # Mock the suggestion methods based on the new config
+        # The order must match the order in config/optimizer_config.yaml
         trial.suggest_int.side_effect = [
-            80,    # spread_limit
             100,   # long_tp
             -100,  # long_sl
             110,   # short_tp
             -110,  # short_sl
-            100,   # entry_price_offset - Note: Converted to int
+            100,   # entry_price_offset
         ]
         trial.suggest_float.side_effect = [
             1.5,   # obi_weight
             1.4,   # ofi_weight
             1.3,   # cvd_weight
             0.4,   # micro_price_weight
-            1.1,   # composite_threshold
+            0.25,  # composite_threshold
             0.2,   # ewma_lambda
+            # Conditional params below
             3.0,   # volatility_factor
             0.7,   # min_threshold_factor
             2.5,   # max_threshold_factor
@@ -66,7 +67,7 @@ class TestConfigRendering(unittest.TestCase):
         # Values for optimized params come from the side_effect lists above.
         # Values for fixed params come from the .template file.
         expected_yaml_structure = {
-            'pair': 'btc_jpy', 'order_amount': 0.01, 'spread_limit': 80,
+            'pair': 'btc_jpy', 'order_amount': 0.01,
             'entry_price_offset': 100,
             'lot_max_ratio': 1.0, 'order_ratio': 0.95,
             'long': {'tp': 100, 'sl': -100},
@@ -74,7 +75,7 @@ class TestConfigRendering(unittest.TestCase):
             'signal': {
                 'hold_duration_ms': 500, 'cvd_window_minutes': 1, 'obi_weight': 1.5,
                 'ofi_weight': 1.4, 'cvd_weight': 1.3, 'micro_price_weight': 0.4,
-                'composite_threshold': 1.1
+                'composite_threshold': 0.25
             },
             'volatility': {
                 'ewma_lambda': 0.2,


### PR DESCRIPTION
オプティマイザがパラメータを見つけられない問題を修正。

WFAの短い学習期間に対して `min_trades_for_pruning` の設定値が
大きすぎたため、ほぼ全ての試行が枝刈りされていました。
この値を5から1に引き下げ、短期間でも評価が行われるように修正。

また、デバッグを容易にするため、枝刈りの理由を詳細にログ出力する
機能を追加し、最適化完了後にサマリーを表示するようにしました。

合わせて、設定変更に追従できていなかったテストコードを修正しました。