### PR TITLE
feat(optimizer): 詳細なデバッグログを追加

### DIFF
--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -10,7 +10,7 @@
 # log_level: 出力するログの詳細レベル。"debug", "info", "warn", "error"から選択。
 # 通常は "info" を使用し、問題調査時には "debug" に変更します。
 # 環境変数 'LOG_LEVEL' で上書き可能です。
-log_level: "info"
+log_level: "debug"
 
 # obi_calculator_channel_size: OBI計算結果を格納するチャネルのバッファサイズ。
 # インジケーター計算（プロデューサー）とシグナル評価（コンシューマー）の間の

--- a/optimizer/data.py
+++ b/optimizer/data.py
@@ -143,6 +143,20 @@ def _split_data_by_timestamp(full_dataset_path: Path, split_time_str: str, cycle
     oos_lines = len((oos_path).read_text().splitlines())
     logging.info(f"Split data into IS ({is_path}, {is_lines} lines) and OOS ({oos_path}, {oos_lines} lines)")
 
+    # --- Temporary logging to inspect data ---
+    if is_lines > 1:
+        with open(is_path, 'r') as f_is_read:
+            is_data_lines = f_is_read.readlines()
+        logging.info("--- Start of IS data sample ---")
+        for line in is_data_lines[:6]: # header + 5 lines
+            logging.info(line.strip())
+        logging.info("...")
+        for line in is_data_lines[-5:]:
+            logging.info(line.strip())
+        logging.info("--- End of IS data sample ---")
+    else:
+        logging.warning("IS data file is empty or contains only a header.")
+
     return is_path, oos_path
 
 

--- a/optimizer/objective.py
+++ b/optimizer/objective.py
@@ -84,6 +84,13 @@ class Objective:
             # Prune the trial to prevent it from being considered a valid candidate.
             raise optuna.exceptions.TrialPruned()
 
+        # Log stderr for debugging purposes, especially to see Go logs
+        if stderr_log:
+            logging.info(f"--- Go simulation log for trial {trial.number} ---")
+            for line in stderr_log.splitlines():
+                logging.info(line)
+            logging.info(f"--- End of Go simulation log for trial {trial.number} ---")
+
         # Calculate metrics, including those from logs
         self._calculate_and_set_metrics(trial, summary, stderr_log)
 


### PR DESCRIPTION
シミュレーションが取引を生成しない問題の根本原因を調査するため、
以下の詳細なデバッグログを有効化します。

- Goシミュレーションのログレベルを "debug" に設定
- Python側でGoシミュレーションの標準エラーを常にログ出力
- 学習用CSVデータの内容をログにサンプリング出力

これらの変更は診断目的であり、根本原因の修正後に元に戻す必要があります。