### PR TITLE
feat(simulator): Goシミュレーションにnilチェックを追加

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1084,7 +1084,14 @@ func runSingleSimulationInMemory(ctx context.Context, tradeCfg *config.TradeConf
 	rand.Seed(1) // Ensure reproducibility
 
 	simConfig := config.GetConfigCopy()
+	if simConfig == nil {
+		return map[string]interface{}{"error": "global config is nil, cannot run simulation"}
+	}
 	simConfig.Trade = tradeCfg // tradeCfg is already a pointer
+
+	if simConfig.Trade == nil {
+		return map[string]interface{}{"error": "trade config for trial is nil"}
+	}
 
 	orderBook := indicator.NewOrderBook()
 	replayEngine := engine.NewReplayExecutionEngine(orderBook)


### PR DESCRIPTION
nil pointer dereferenceによるpanicの根本原因を特定するため、
`runSingleSimulationInMemory` 関数にnilチェックを追加。

これにより、グローバル設定と試行ごとの設定のどちらに
問題があるかを正確に切り分ける。