### PR TITLE
feat(simulator): 強制的にデバッグログを有効化し、nilチェックを追加

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -415,7 +415,7 @@ func compareStructs(v1, v2 reflect.Value, prefix string) {
 
 // setupLogger initializes the global logger.
 func setupLogger(logLevel, configPath, pair string) {
-	logger.SetGlobalLogLevel(logLevel)
+	logger.SetGlobalLogLevel("debug") // Force debug logging
 	logger.Info("OBI Scalping Bot starting...")
 	logger.Infof("Loaded configuration from: %s", configPath)
 	if pair != "" {
@@ -1082,7 +1082,14 @@ func runSingleSimulationInMemory(ctx context.Context, tradeCfg *config.TradeConf
 	rand.Seed(1) // Ensure reproducibility
 
 	simConfig := config.GetConfigCopy()
+	if simConfig == nil {
+		return map[string]interface{}{"error": "global config is nil, cannot run simulation"}
+	}
 	simConfig.Trade = tradeCfg // tradeCfg is already a pointer
+
+	if simConfig.Trade == nil {
+		return map[string]interface{}{"error": "trade config for trial is nil"}
+	}
 
 	orderBook := indicator.NewOrderBook()
 	replayEngine := engine.NewReplayExecutionEngine(orderBook)


### PR DESCRIPTION
panicの原因を特定するため、診断用のコードを再度追加。

- ログレベルを"debug"にハードコードし、デバッグログ出力を強制。
- シミュレーション関数にnilチェックを再追加し、設定オブジェクトが nilの場合に明確なエラーを返すようにする。