### PR TITLE
fix(config): DB接続情報の読み込みロジックを修正

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,6 +214,21 @@ func loadConfigFromBytes(appConfigPath string, tradeConfigBytes []byte) (*Config
 	if logLevel := os.Getenv("LOG_LEVEL"); logLevel != "" {
 		cfg.App.LogLevel = logLevel
 	}
+	if dbHost := os.Getenv("DB_HOST"); dbHost != "" {
+		cfg.App.Database.Host = dbHost
+	}
+	if dbUser := os.Getenv("DB_USER"); dbUser != "" {
+		cfg.App.Database.User = dbUser
+	}
+	if dbPassword := os.Getenv("DB_PASSWORD"); dbPassword != "" {
+		cfg.App.Database.Password = dbPassword
+	}
+	if dbName := os.Getenv("DB_NAME"); dbName != "" {
+		cfg.App.Database.Name = dbName
+	}
+	if dbSSLMode := os.Getenv("DB_SSLMODE"); dbSSLMode != "" {
+		cfg.App.Database.SSLMode = dbSSLMode
+	}
 	cfg.EnableTrade = os.Getenv("ENABLE_TRADE") == "true"
 
 	return cfg, nil


### PR DESCRIPTION
`internal/config/config.go`のリファクタリング中に、環境変数からデータベース接続情報を読み込む処理が欠落していました。 これにより、データエクスポート時に認証エラーが発生していました。

この修正で、環境変数から正しく認証情報が読み込まれるようになり、データベース接続が回復します。

加えて、以前のコミットで実施したオプティマイザのパラメータ探索空間の修正も含まれています。