### PR TITLE
perf(optimizer): 粗探索の試行回数を削減し、fine-phaseのバッチ処理を修正

### DIFF
--- a/config/optimizer_config.yaml
+++ b/config/optimizer_config.yaml
@@ -30,7 +30,7 @@ min_trades_for_pruning: 10
 # 最初に広い探索空間で有望な領域を特定し（coarse）、次にその領域を深く探索します（fine）。
 coarse_to_fine:
   enabled: true
-  coarse_trials: 300
+  coarse_trials: 100
   fine_trials: 200
   top_trials_quantile_for_kde: 0.2
 

--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -139,7 +139,7 @@ def run_optimization(study: optuna.Study, is_csv_path: Path, n_trials: int, stor
         sampler=kde_sampler
     )
 
-    _run_single_phase_optimization(fine_study, is_csv_path, config.CTF_FINE_TRIALS, "fine-phase")
+    _run_batch_optimization(fine_study, is_csv_path, config.CTF_FINE_TRIALS)
 
     # The original study object is now replaced by the fine_study object
     # to allow the rest of the pipeline to analyze the results of the fine phase.


### PR DESCRIPTION
オプティマイザの粗探索（coarse-phase）が低速である問題に対処するため、試行回数を300から100に削減しました。

また、前回のリファクタリングで、詳細探索（fine-phase）が新しいバッチ処理関数を呼び出しておらず、`NameError`が発生していた問題を修正しました。

- `config/optimizer_config.yaml`: `coarse_trials` を `300` から `100` に変更。
- `optimizer/study.py`: `fine-phase`も`_run_batch_optimization`を呼び出すように修正。