### PR TITLE
fix(optimizer): numpyのデータ型がJSONシリアライズできない問題を修正

### DIFF
--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -59,7 +59,16 @@ def _run_batch_optimization(study: optuna.Study, is_csv_path: Path, n_trials: in
         for trial in trials:
             flat_params = Objective._suggest_parameters(trial)
             # Convert numpy types to native Python types for JSON serialization
-            serializable_params = {k: (int(v) if isinstance(v, np.integer) else v) for k, v in flat_params.items()}
+            serializable_params = {}
+            for k, v in flat_params.items():
+                if isinstance(v, np.integer):
+                    serializable_params[k] = int(v)
+                elif isinstance(v, np.floating):
+                    serializable_params[k] = float(v)
+                elif isinstance(v, np.bool_):
+                    serializable_params[k] = bool(v)
+                else:
+                    serializable_params[k] = v
             trial.set_user_attr("params_flat", serializable_params) # Store params for later
             batch_requests.append({
                 "trial_id": trial.number,


### PR DESCRIPTION
`trial.set_user_attr`を呼び出す際に、パラメータ辞書に`numpy.int64`や`numpy.bool_`などのnumpy特有のデータ型が含まれていると、JSONシリアライズに失敗し`TypeError`が発生していました。

この問題を解決するため、`set_user_attr`を呼び出す前に、numpyの数値型やブール型をPython標準の型（int, float, bool）に汎用的に変換する処理を追加しました。