### PR TITLE
fix(optimizer): バッチリクエスト作成時のJSONシリアライズエラーを修正

### DIFF
--- a/optimizer/study.py
+++ b/optimizer/study.py
@@ -72,7 +72,7 @@ def _run_batch_optimization(study: optuna.Study, is_csv_path: Path, n_trials: in
             trial.set_user_attr("params_flat", serializable_params) # Store params for later
             batch_requests.append({
                 "trial_id": trial.number,
-                "trade_config": nest_params(flat_params)
+                "trade_config": nest_params(serializable_params)
             })
 
         # 3. Run the entire batch


### PR DESCRIPTION
`_run_batch_optimization`内で、Goのシミュレーションサーバーに送信するバッチリクエストを作成する際に、型変換前のパラメータを使用していたため、`TypeError`が発生していました。

この修正では、Pythonネイティブ型に変換済みの`serializable_params`を使用してバッチリクエストを作成するように変更し、問題を解決しました。