### PR TITLE
fix(optimizer): Coarse-to-Fineのstudyが正しく使われるように修正

### DIFF
--- a/docs/optimizer/README.md
+++ b/docs/optimizer/README.md
@@ -22,7 +22,7 @@
 ## 3. モジュール構成
 
 -   `optimizer/main.py`: ファイル監視ループも含む。
--   `optimizer/study.py`: 1サイクル分のOptuna最適化（IS最適化とOOS検証）を実行し、結果を返す。
+-   `optimizer/study.py`: 1サイクル分のOptuna最適化（IS最適化とOOS検証）を実行し、結果を返す。Coarse-to-Fine最適化が有効な場合、このモジュールは2段階の探索（粗探索と密探索）を管理し、最終的な検証には密探索フェーズの結果（`fine_study`）が使用される。
 -   `optimizer/data.py`: 指定された時間枠のデータをエクスポートし、IS/OOSに分割する。
 -   `optimizer/config.py`: `optimizer_config.yaml`から設定を読み込む。
 -   `optimizer/objective.py`: Optunaの目的関数を定義する。`_suggest_parameters`メソッドは、`optimizer_config.yaml`内の`parameter_space`セクションに基づいてパラメータの探索範囲を動的に決定します。

--- a/optimizer/walk_forward.py
+++ b/optimizer/walk_forward.py
@@ -93,11 +93,12 @@ def run_walk_forward_analysis(job: dict) -> bool:
 
                 # b. Create and run an Optuna study on the training data
                 storage_path = f"sqlite:///{fold_dir / 'optuna-study.db'}"
-                fold_study = study.create_study(storage_path=storage_path, study_name=fold_id)
-                study.run_optimization(fold_study, train_csv, n_trials, storage_path)
+                initial_fold_study = study.create_study(storage_path=storage_path, study_name=fold_id)
+                # run_optimization may return a new study object (e.g., from a fine-tuning phase)
+                final_fold_study = study.run_optimization(initial_fold_study, train_csv, n_trials, storage_path)
 
                 # c. Take the best parameters and validate them on the validation data
-                fold_result = _validate_fold(fold_study, validate_csv)
+                fold_result = _validate_fold(final_fold_study, validate_csv)
                 all_fold_results.append(fold_result)
 
             except Exception as e:


### PR DESCRIPTION
Coarse-to-Fine最適化において、Phase 2 (Fine Search) の結果が後続の検証ステップで正しく使用されていなかった問題を修正しました。

- `optimizer/study.py`の`run_optimization`関数が、Fine Search完了後に新しい`fine_study`オブジェクトを返すように変更。
- `optimizer/walk_forward.py`の呼び出し元が、返されたstudyオブジェクトを検証に使用するように修正。
- `docs/optimizer/README.md`を更新し、現在の実装と一致するように修正。

これにより、optimizerが意図せず終了する問題が解決され、ジョブ完了後も継続して次のジョブを待機するようになります。