### PR TITLE
feat(report): PNLレポート生成間隔を設定ファイルで可変にする

### DIFF
--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -64,3 +64,11 @@ db_writer:
   batch_size: 100
   # write_interval_seconds: バッファからDBへの書き込みを行う間隔（秒）。
   write_interval_seconds: 5
+
+# ------------------------------------------------------------------------------
+# レポート生成設定 (Report Generator Settings)
+# ------------------------------------------------------------------------------
+report_generator:
+  # interval_minutes: PNLレポートを生成する間隔（分）。
+  # 0以下の値を設定すると、デフォルト値（60分）が使用されます。
+  interval_minutes: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,6 @@ services:
     container_name: obi-scalp-report-generator
     environment:
       - DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@timescaledb:${DB_PORT}/${DB_NAME}?sslmode=disable
-      - REPORT_INTERVAL_MINUTES=1
     depends_on:
       timescaledb:
         condition: service_healthy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,9 +17,15 @@ type AppConfig struct {
 	ObiCalculatorChannelSize   int            `yaml:"obi_calculator_channel_size"`
 	SignalEvaluationIntervalMs int            `yaml:"signal_evaluation_interval_ms"`
 	Order                      OrderConfig    `yaml:"order"`
-	Database                   DatabaseConfig `yaml:"database"`
-	DBWriter                   DBWriterConfig `yaml:"db_writer"`
-	Replay                     ReplayConfig   `yaml:"replay"`
+	Database                   DatabaseConfig        `yaml:"database"`
+	DBWriter                   DBWriterConfig        `yaml:"db_writer"`
+	Replay                     ReplayConfig          `yaml:"replay"`
+	ReportGenerator            ReportGeneratorConfig `yaml:"report_generator"`
+}
+
+// ReportGeneratorConfig holds configuration for the PNL report generator.
+type ReportGeneratorConfig struct {
+	IntervalMinutes int `yaml:"interval_minutes"`
 }
 
 // TradeConfig defines the structure for trading strategy configuration.


### PR DESCRIPTION
pnl_reports の作成間隔を1分から5分に変更し、その値を `config/app_config.yaml` で設定できるように修正しました。

主な変更点:
- PNLレポートの生成間隔をデフォルトで5分に変更。
- `config/app_config.yaml` に `report_generator.interval_minutes` を追加し、間隔を分単位で指定できるようにした。
- `cmd/report/main.go` が環境変数の代わりに設定ファイルを参照するようにロジックを更新。
- 廃止された `REPORT_INTERVAL_MINUTES` 環境変数を `docker-compose.yml` から削除。
- 関連ドキュメントを更新し、新しい設定方法を反映。

既存の仕様通り、指定した間隔内に新しい取引がない場合は、pnl_reports レコードは作成されません。このロジックは `cmd/report/main.go` に既に実装されており、今回の変更では影響ありません。