### PR TITLE
fix(report): report-generatorのコンテナ起動失敗を修正

### DIFF
--- a/cmd/report/Dockerfile
+++ b/cmd/report/Dockerfile
@@ -18,10 +18,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o /go/bin/report-gene
 # ---- Final Image ----
 FROM scratch
 
+WORKDIR /app
+
 # Copy the static binary from the builder stage
-COPY --from=builder /go/bin/report-generator /report-generator
+COPY --from=builder /go/bin/report-generator /app/report-generator
 # Copy ca-certificates for TLS
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Command to run the application
-ENTRYPOINT ["/report-generator"]
+ENTRYPOINT ["/app/report-generator"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,8 @@ services:
       context: .
       dockerfile: cmd/report/Dockerfile
     container_name: obi-scalp-report-generator
+    volumes:
+      - ./config:/app/config:ro
     environment:
       - DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@timescaledb:${DB_PORT}/${DB_NAME}?sslmode=disable
     depends_on:


### PR DESCRIPTION
`report-generator`サービスが設定ファイルを読み込めずにクラッシュする問題を修正しました。

主な修正点:
- `cmd/report/Dockerfile` に `WORKDIR /app` を追加し、他のサービスとの一貫性を確保。
- `docker-compose.yml` の `report-generator` サービスに `config` ディレクトリをマウントする `volumes` 設定を追加。

これにより、コンテナ内から `config/app_config.yaml` が正しく参照できるようになり、サービスが正常に起動します。