### PR TITLE
fix(report): report-generatorのDB認証失敗を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,8 @@ services:
     container_name: obi-scalp-report-generator
     volumes:
       - ./config:/app/config:ro
+    env_file:
+      - .env
     environment:
       - DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@timescaledb:${DB_PORT}/${DB_NAME}?sslmode=disable
     depends_on:


### PR DESCRIPTION
`report-generator`サービスがデータベースへの接続に失敗する問題を修正しました。

`docker-compose.yml`の`report-generator`サービスの定義に`env_file`の指定が漏れていたため、`.env`ファイルから正しいデータベース接続情報（特にパスワード）が読み込まれていませんでした。

この修正により、サービス定義に`env_file: - .env`を追加し、コンテナが正しい環境変数で起動されるようにしました。