### PR TITLE
feat(optimizer): Increase spread_limit search range

### DIFF
--- a/config/optimizer_config.yaml
+++ b/config/optimizer_config.yaml
@@ -97,7 +97,7 @@ analyzer:
 parameter_space:
   spread_limit:
     type: "categorical"
-    choices: [20, 40, 60, 80]
+    choices: [20, 40, 60, 80, 500, 1000, 2000, 4000, 8000, 12000, 18000]
   long_tp:
     type: "categorical"
     choices: [6000, 8000, 9000, 10000, 12000]


### PR DESCRIPTION
Increase the search range for the `spread_limit` parameter in the optimizer configuration.

The user requested to allow `spread_limit` to be up to 1.5 times the `long_tp` or `short_tp` values. This change expands the list of choices for `spread_limit` to include values up to 18000, giving the optimizer a wider space to search for the optimal parameter.

The new choices are: `[20, 40, 60, 80, 500, 1000, 2000, 4000, 8000, 12000, 18000]`