### PR TITLE
fix(report): total_tradesが0のpnl_reportsレコードが生成される問題を修正

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -116,7 +116,13 @@ func runReportGeneration(repo datastore.Repository, reportService *report.Servic
 		return
 	}
 
-	// 4. Save the report
+	// 4. Final check before saving
+	if analysisReport.TotalTrades == 0 {
+		l.Info("No completed trades to generate a report.")
+		return
+	}
+
+	// 5. Save the report
 	if err := reportService.SavePnlReport(ctx, analysisReport); err != nil {
 		l.Errorf("Failed to save PnL report: %v", err)
 		return


### PR DESCRIPTION
pnl_reportsテーブルに、分析対象の完了済み取引がないにも関わらず`total_trades`が0のレコードが作成されてしまう問題を修正しました。

`cmd/report/main.go`において、`AnalyzeTrades`関数から返されたレポートを保存する直前に、`analysisReport.TotalTrades`が0でないことを確認するチェックを追加しました。

これにより、未決済の取引やキャンセルされた取引のみが存在する期間において、不要なレポートが生成されることを防ぎます。