### PR TITLE
feat: Use slim TimescaleDB image and pin version

### DIFF
--- a/db/Dockerfile.slim
+++ b/db/Dockerfile.slim
@@ -1,0 +1,10 @@
+# db/Dockerfile.slim
+# ベースは最小系タグ（Aで固定したもの）
+FROM timescale/timescaledb:2.21.1-pg16-oss
+
+# pgvector を使わない場合のみ：関連ファイルを削除して数十MB級のスリム化
+# （必要になったらこの派生利用をやめ、元イメージに戻してください）
+RUN rm -rf /usr/local/lib/postgresql/*vector* \
+           /usr/local/share/postgresql/extension/*vector*
+
+# そのほか不要物の削除は最小限に留める（JIT/LLVM・timescaledb本体は削らない）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,10 @@ services:
       - bot_network
 
   timescaledb:
-    image: timescale/timescaledb:2.11.2-pg14
+    build:
+      context: ./db
+      dockerfile: Dockerfile.slim
+    image: local/tsdb-slim:2.21.1-pg16-oss
     container_name: timescaledb-obi
     ports:
       - "5432:5432"


### PR DESCRIPTION
- Pins the TimescaleDB image to `timescale/timescaledb:2.21.1-pg16-oss`.
- Adds a new `db/Dockerfile.slim` to build a derived image that removes `pgvector` to reduce image size.
- Updates `docker-compose.yml` to build the `timescaledb` service from the new Dockerfile.
- Preserves all existing configurations for the service.